### PR TITLE
feat(error-boundary): component handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 effect/
 .trygg/
+.overseer/

--- a/apps/examples/app/pages/error-boundary.tsx
+++ b/apps/examples/app/pages/error-boundary.tsx
@@ -32,28 +32,15 @@ const ErrorBoundaryPage = Component.gen(function* () {
 
   // Create error-boundary-wrapped component with specific handlers + catchAll
   const SafeRiskyComponent = yield* ErrorBoundary.catch(RiskyComponent)
-    .on("NetworkError", (cause) => {
-      const error = Cause.squash(cause) as NetworkError;
-      return <NetworkErrorDisplay error={error} />;
-    })
-    .on("ValidationError", (cause) => {
-      const error = Cause.squash(cause) as ValidationError;
-      return <ValidationErrorDisplay error={error} />;
-    })
-    .on("UnknownError", (cause) => {
-      const error = Cause.squash(cause) as UnknownError;
-      return <UnknownErrorDisplay error={error} />;
-    })
-    .catchAll((cause) => {
-      // Fallback for any other errors
-      const error = Cause.squash(cause);
-      return (
-        <div className="p-4 rounded bg-red-100 text-red-800">
-          <h3 className="mt-0">Unexpected Error</h3>
-          <pre>{String(error)}</pre>
-        </div>
-      );
-    });
+    .on("NetworkError", NetworkErrorDisplay)
+    .on("ValidationError", ValidationErrorDisplay)
+    .on("UnknownError", UnknownErrorDisplay)
+    .catchAll((cause) => (
+      <div className="p-4 rounded bg-red-100 text-red-800">
+        <h3 className="mt-0">Unexpected Error</h3>
+        <pre>{String(Cause.squash(cause))}</pre>
+      </div>
+    ));
 
   return (
     <div className="bg-white p-6 rounded-lg border border-gray-200">

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "watcher": {
+    "ignore": [
+      "node_modules/**",
+      "effect/**",
+      ".effect/**",
+      ".trygg/**",
+      "dist/**",
+      "out/**",
+      "*.db",
+      "*.sqlite",
+      "*.sqlite3",
+      ".jj/**",
+      ".git/**",
+      "coverage/**"
+    ]
+  }
+}

--- a/packages/core/src/components/__tests__/components.test.tsx
+++ b/packages/core/src/components/__tests__/components.test.tsx
@@ -48,13 +48,12 @@ describe("ErrorBoundary", () => {
         return <div>Success</div>;
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(SuccessComponent).catchAll(() => (
-        <div>Error</div>
-      ));
+      const builder = ErrorBoundary.catch(SuccessComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>Error</div>);
 
       const { getByText } = yield* render(<SafeComponent />);
 
-      assert.isDefined(getByText("Success"));
+      assert.isDefined(yield* getByText("Success"));
     }),
   );
 
@@ -64,13 +63,12 @@ describe("ErrorBoundary", () => {
         return yield* new TestError({ message: "Test error" });
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(FailingComponent).catchAll(() => (
-        <div>Fallback shown</div>
-      ));
+      const builder = ErrorBoundary.catch(FailingComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>Fallback shown</div>);
 
       const { getByText } = yield* render(<SafeComponent />);
 
-      assert.isDefined(getByText("Fallback shown"));
+      assert.isDefined(yield* getByText("Fallback shown"));
     }),
   );
 
@@ -80,16 +78,20 @@ describe("ErrorBoundary", () => {
         return yield* new TestError({ message: "Specific error" });
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(FailingComponent)
-        .on("TestError", (cause) => {
-          const error = Cause.squash(cause) as TestError;
-          return <div>Error: {error.message}</div>;
-        })
-        .catchAll(() => <div>Generic error</div>);
+      const TestErrorView = Component.gen(function* (
+        Props: Component.ComponentProps<{ error: TestError }>,
+      ) {
+        const { error } = yield* Props;
+        return <div>Error: {error.message}</div>;
+      });
+
+      const builder = ErrorBoundary.catch(FailingComponent);
+      const withHandler = builder.on("TestError", TestErrorView);
+      const SafeComponent = yield* withHandler.catchAll(() => <div>Generic error</div>);
 
       const { getByText } = yield* render(<SafeComponent />);
 
-      assert.isDefined(getByText("Error: Specific error"));
+      assert.isDefined(yield* getByText("Error: Specific error"));
     }),
   );
 
@@ -99,14 +101,14 @@ describe("ErrorBoundary", () => {
         return yield* new OtherError();
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(FailingComponent).catchAll((cause) => {
-        const error = Cause.squash(cause);
-        return <div data-testid="catch-all">Catch-all: {String(error)}</div>;
-      });
+      const builder = ErrorBoundary.catch(FailingComponent);
+      const SafeComponent = yield* builder.catchAll((cause) => (
+        <div data-testid="catch-all">Catch-all: {String(Cause.squash(cause))}</div>
+      ));
 
       const { getByTestId } = yield* render(<SafeComponent />);
 
-      assert.isDefined(getByTestId("catch-all"));
+      assert.isDefined(yield* getByTestId("catch-all"));
     }),
   );
 
@@ -118,13 +120,12 @@ describe("ErrorBoundary", () => {
 
       const staticFallback = <div data-testid="static-fallback">Static fallback content</div>;
 
-      const SafeComponent = yield* ErrorBoundary.catch(FailingComponent).catchAll(
-        () => staticFallback,
-      );
+      const builder = ErrorBoundary.catch(FailingComponent);
+      const SafeComponent = yield* builder.catchAll(() => staticFallback);
 
       const { getByTestId } = yield* render(<SafeComponent />);
 
-      assert.isDefined(getByTestId("static-fallback"));
+      assert.isDefined(yield* getByTestId("static-fallback"));
     }),
   );
 
@@ -134,18 +135,16 @@ describe("ErrorBoundary", () => {
         return yield* new TestError({ message: "Inner error" });
       });
 
-      const InnerSafe = yield* ErrorBoundary.catch(InnerFailing as any).catchAll(() => (
-        <div>Inner fallback</div>
-      ));
+      const innerBuilder = ErrorBoundary.catch(InnerFailing);
+      const InnerSafe = yield* innerBuilder.catchAll(() => <div>Inner fallback</div>);
 
-      const OuterSafe = yield* ErrorBoundary.catch(InnerSafe as any).catchAll(() => (
-        <div>Outer fallback</div>
-      ));
+      const outerBuilder = ErrorBoundary.catch(InnerSafe);
+      const OuterSafe = yield* outerBuilder.catchAll(() => <div>Outer fallback</div>);
 
       const { getByText, queryByText } = yield* render(<OuterSafe />);
 
       // Inner boundary should catch, outer should not be triggered
-      assert.isDefined(getByText("Inner fallback"));
+      assert.isDefined(yield* getByText("Inner fallback"));
       assert.isNull(queryByText("Outer fallback"));
     }),
   );
@@ -163,14 +162,15 @@ describe("ErrorBoundary", () => {
         return <div data-testid="child">Child content</div>;
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(ChildComponent as any).catchAll(() => (
+      const builder = ErrorBoundary.catch(ChildComponent);
+      const SafeComponent = yield* builder.catchAll(() => (
         <div data-testid="fallback">Error caught!</div>
       ));
 
       const { getByTestId, queryByTestId } = yield* render(<SafeComponent />);
 
       // Initial render should show child
-      assert.isDefined(getByTestId("child"));
+      assert.isDefined(yield* getByTestId("child"));
       assert.isNull(queryByTestId("fallback"));
 
       // Trigger re-render that throws
@@ -178,7 +178,7 @@ describe("ErrorBoundary", () => {
       yield* TestClock.adjust(20);
 
       // Should show fallback, child should be gone
-      assert.isDefined(getByTestId("fallback"));
+      assert.isDefined(yield* getByTestId("fallback"));
       assert.isNull(queryByTestId("child"));
     }),
   );
@@ -197,21 +197,18 @@ describe("ErrorBoundary", () => {
         return <div data-testid="ok">OK</div>;
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(ChildComponent).catchAll(() => (
-        <div data-testid="fallback">Fallback</div>
-      ));
+      const builder = ErrorBoundary.catch(ChildComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div data-testid="fallback">Fallback</div>);
 
-      const { getByTestId, queryByTestId } = yield* render(
-        <SafeComponent mode={mode} />,
-      );
+      const { getByTestId, queryByTestId } = yield* render(<SafeComponent mode={mode} />);
 
-      assert.isDefined(getByTestId("ok"));
+      assert.isDefined(yield* getByTestId("ok"));
       assert.isNull(queryByTestId("fallback"));
 
       yield* Signal.set(mode, "error");
       yield* TestClock.adjust(20);
 
-      assert.isDefined(getByTestId("fallback"));
+      assert.isDefined(yield* getByTestId("fallback"));
       assert.isNull(queryByTestId("ok"));
     }),
   );
@@ -222,13 +219,12 @@ describe("ErrorBoundary", () => {
         return <div data-testid="static-child">Static content</div>;
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(StaticComponent as any).catchAll(() => (
-        <div>Error fallback</div>
-      ));
+      const builder = ErrorBoundary.catch(StaticComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>Error fallback</div>);
 
       const { getByTestId } = yield* render(<SafeComponent />);
 
-      assert.isDefined(getByTestId("static-child"));
+      assert.isDefined(yield* getByTestId("static-child"));
     }),
   );
 
@@ -244,14 +240,15 @@ describe("ErrorBoundary", () => {
         return <div data-testid="content">Good content</div>;
       });
 
-      const SafeComponent = yield* ErrorBoundary.catch(ChildComponent as any).catchAll(() => (
+      const builder = ErrorBoundary.catch(ChildComponent);
+      const SafeComponent = yield* builder.catchAll(() => (
         <div data-testid="fallback">Signal error caught</div>
       ));
 
       const { getByTestId, queryByTestId } = yield* render(<SafeComponent />);
 
       // Initial render
-      assert.isDefined(getByTestId("content"));
+      assert.isDefined(yield* getByTestId("content"));
       assert.isNull(queryByTestId("fallback"));
 
       // Trigger error via signal change - component will re-render and throw
@@ -259,7 +256,7 @@ describe("ErrorBoundary", () => {
       yield* TestClock.adjust(20);
 
       // Should catch error and show fallback
-      assert.isDefined(getByTestId("fallback"));
+      assert.isDefined(yield* getByTestId("fallback"));
       assert.isNull(queryByTestId("content"));
     }),
   );
@@ -267,30 +264,31 @@ describe("ErrorBoundary", () => {
   it.scoped("should throw if adding handler after catchAll", () =>
     Effect.gen(function* () {
       const Component_ = Component.gen(function* () {
-        return <div>OK</div>;
+        return yield* new TestError({ message: "fail" });
       });
 
-      const builder = ErrorBoundary.catch(Component_ as any);
+      const builder = ErrorBoundary.catch(Component_);
+
+      const TestErrorView = Component.gen(function* (
+        Props: Component.ComponentProps<{ error: TestError }>,
+      ) {
+        yield* Props;
+        return <div>Test</div>;
+      });
 
       // First add catchAll
       yield* builder.catchAll(() => <div>Error</div>);
 
-      // Then try to add .on() - should throw
-      const exit = yield* Effect.exit(
-        Effect.try(() => {
-          builder.on("TestError", () => <div>Test</div>);
-        }),
-      );
+      // Then try to add .on() - should fail on finalization
+      const badBuilder = builder.on("TestError", TestErrorView);
+      const exit = yield* Effect.exit(badBuilder.catchAll(() => <div>Fallback</div>));
 
       assert.isTrue(Exit.isFailure(exit));
       if (Exit.isFailure(exit)) {
         const error = Cause.squash(exit.cause);
-        assert.isTrue(error instanceof Error);
-        if (error instanceof Error && error.cause instanceof Error) {
-          assert.strictEqual(
-            error.cause.message,
-            "Cannot add .on() handler after .catchAll()",
-          );
+        assert.isTrue(error instanceof ErrorBoundary.BuilderError);
+        if (error instanceof ErrorBoundary.BuilderError) {
+          assert.strictEqual(error.reason, "on-after-catchAll");
         }
       }
     }),
@@ -299,24 +297,35 @@ describe("ErrorBoundary", () => {
   it.scoped("should throw on duplicate handler", () =>
     Effect.gen(function* () {
       const Component_ = Component.gen(function* () {
-        return <div>OK</div>;
+        return yield* new TestError({ message: "fail" });
       });
 
-      const builder = ErrorBoundary.catch(Component_ as any).on("TestError", () => <div>Test</div>);
+      const builder = ErrorBoundary.catch(Component_);
+      const TestErrorView = Component.gen(function* (
+        Props: Component.ComponentProps<{ error: TestError }>,
+      ) {
+        yield* Props;
+        return <div>Test</div>;
+      });
+      const DuplicateErrorView = Component.gen(function* (
+        Props: Component.ComponentProps<{ error: TestError }>,
+      ) {
+        yield* Props;
+        return <div>Test 2</div>;
+      });
+      const withHandler = builder.on("TestError", TestErrorView);
 
-      // Try to add duplicate handler
-      const exit = yield* Effect.exit(
-        Effect.try(() => {
-          builder.on("TestError", () => <div>Test 2</div>);
-        }),
-      );
+      // Try to add duplicate handler - should fail on finalization
+      const badBuilder = withHandler.on("TestError", DuplicateErrorView);
+      const exit = yield* Effect.exit(badBuilder.catchAll(() => <div>Fallback</div>));
 
       assert.isTrue(Exit.isFailure(exit));
       if (Exit.isFailure(exit)) {
         const error = Cause.squash(exit.cause);
-        assert.isTrue(error instanceof Error);
-        if (error instanceof Error && error.cause instanceof Error) {
-          assert.strictEqual(error.cause.message, "Duplicate handler for error tag: TestError");
+        assert.isTrue(error instanceof ErrorBoundary.BuilderError);
+        if (error instanceof ErrorBoundary.BuilderError) {
+          assert.strictEqual(error.reason, "duplicate-handler");
+          assert.strictEqual(error.tag, "TestError");
         }
       }
     }),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,7 +161,6 @@ export { DevMode, type DevModeProps } from "./components/dev-mode.js";
 
 // ErrorBoundary
 export * as ErrorBoundary from "./primitives/error-boundary.js";
-export { type ErrorHandler } from "./primitives/error-boundary.js";
 
 // Portal
 export * as Portal from "./primitives/portal.js";

--- a/packages/core/src/primitives/__tests__/error-boundary.test.tsx
+++ b/packages/core/src/primitives/__tests__/error-boundary.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * ErrorBoundary Unit Tests
+ *
+ * ErrorBoundary provides functional composition for error handling.
+ * Wraps components with error boundaries that catch errors and render fallback UIs.
+ *
+ * Test Categories:
+ * - catch/catchAll: Basic error boundary wrapping
+ * - .provide() preservation: Error boundary behavior after .provide() called
+ * - Handler requirements: Service requirements propagation
+ * - Builder validation: Invalid chain detection
+ *
+ * Goals: Reliability, stability
+ * - Verify error boundaries catch errors
+ * - Verify .provide() preserves boundary behavior
+ * - Verify handler requirements are propagated
+ */
+import { assert, describe, it } from "@effect/vitest";
+import { Cause, Context, Data, Effect, Exit, Layer } from "effect";
+import * as Component from "../component.js";
+import * as ErrorBoundary from "../error-boundary.js";
+import * as Signal from "../signal.js";
+import { render } from "../../testing/index.js";
+
+// =============================================================================
+// Test Errors
+// =============================================================================
+
+class TestError extends Data.TaggedError("TestError")<{}> {}
+class NetworkError extends Data.TaggedError("NetworkError")<{}> {}
+
+// =============================================================================
+// .provide() preservation
+// =============================================================================
+
+describe("ErrorBoundary .provide() preservation", () => {
+  it.scoped("provide preserves error boundary wrapper", () =>
+    Effect.gen(function* () {
+      const TestService = Context.GenericTag<string>("TestService");
+      const TestLayer = Layer.succeed(TestService, "provided-value");
+
+      const FailingComponent = Component.gen(function* () {
+        yield* new TestError();
+        return <div>should not render</div>;
+      });
+
+      const builder = ErrorBoundary.catch(FailingComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>fallback</div>);
+
+      // Apply .provide() - this should NOT break the error boundary
+      const ProvidedComponent = SafeComponent.provide(TestLayer);
+      const element = ProvidedComponent({});
+
+      // Render and assert fallback shown, not crash
+      const { getByText, queryByText } = yield* render(element);
+
+      assert.isDefined(yield* getByText("fallback"));
+      assert.isNull(queryByText("should not render"));
+    }),
+  );
+
+  it.scoped("services provided via .provide() available inside wrapped tree", () =>
+    Effect.gen(function* () {
+      const TestService = Context.GenericTag<string>("TestService");
+      const TestLayer = Layer.succeed(TestService, "provided-value");
+
+      const ServiceComponent = Component.gen(function* () {
+        const value = yield* TestService;
+        return <div data-testid="service-value">{value}</div>;
+      });
+
+      const builder = ErrorBoundary.catch(ServiceComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>error</div>);
+
+      const ProvidedComponent = SafeComponent.provide(TestLayer);
+      const element = ProvidedComponent({});
+
+      const { getByTestId } = yield* render(element);
+
+      assert.strictEqual((yield* getByTestId("service-value")).textContent, "provided-value");
+    }),
+  );
+
+  it.scoped("isEffectComponent remains true and error boundary works", () =>
+    Effect.gen(function* () {
+      const FailingComponent = Component.gen(function* () {
+        yield* new TestError();
+        return <div>test</div>;
+      });
+
+      const builder = ErrorBoundary.catch(FailingComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>fallback</div>);
+
+      // Verify it's an effect component
+      assert.isTrue(Component.isEffectComponent(SafeComponent));
+
+      // Actually render and verify error boundary works
+      const { getByText } = yield* render(<SafeComponent />);
+      assert.isDefined(yield* getByText("fallback"));
+    }),
+  );
+});
+
+// =============================================================================
+// Handler requirements propagation
+// =============================================================================
+
+describe("ErrorBoundary handler requirements propagation", () => {
+  it.scoped("propagates handler service requirements", () =>
+    Effect.gen(function* () {
+      const ErrorTheme = Context.GenericTag<string>("ErrorTheme");
+      const ErrorThemeLayer = Layer.succeed(ErrorTheme, "error-theme");
+
+      const RiskyComponent = Component.gen(function* () {
+        yield* new NetworkError();
+        return <div />;
+      });
+
+      const ThemedFallback = Component.gen(function* (
+        Props: Component.ComponentProps<{ error: NetworkError }>,
+      ) {
+        yield* Props;
+        const theme = yield* ErrorTheme;
+        return <div className={theme}>error</div>;
+      });
+
+      const builder = ErrorBoundary.catch(RiskyComponent);
+      const withHandler = builder.on("NetworkError", ThemedFallback);
+      const SafeComponent = yield* withHandler.catchAll(() => <div>generic</div>);
+
+      // Render with ErrorTheme provided - should work
+      const ProvidedComponent = SafeComponent.provide(ErrorThemeLayer);
+      const element = ProvidedComponent({});
+
+      const { getByText } = yield* render(element);
+
+      assert.isDefined(yield* getByText("error"));
+    }),
+  );
+});
+
+// =============================================================================
+// Basic functionality
+// =============================================================================
+
+describe("ErrorBoundary basic functionality", () => {
+  it.scoped("catchAll renders fallback on error", () =>
+    Effect.gen(function* () {
+      const FailingComponent = Component.gen(function* () {
+        yield* new TestError();
+        return <div>should not render</div>;
+      });
+
+      const builder = ErrorBoundary.catch(FailingComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>fallback</div>);
+
+      const { getByText } = yield* render(<SafeComponent />);
+
+      assert.isDefined(yield* getByText("fallback"));
+    }),
+  );
+
+  it.scoped("on() handler matches specific error tags", () =>
+    Effect.gen(function* () {
+      const RiskyComponent = Component.gen(function* () {
+        yield* new NetworkError();
+        return <div>should not render</div>;
+      });
+
+      const NetworkErrorView = Component.gen(function* (
+        Props: Component.ComponentProps<{ error: NetworkError }>,
+      ) {
+        yield* Props;
+        return <div>network-error</div>;
+      });
+
+      const builder = ErrorBoundary.catch(RiskyComponent);
+      const withHandler = builder.on("NetworkError", NetworkErrorView);
+      const SafeComponent = yield* withHandler.catchAll(() => <div>generic-error</div>);
+
+      const { getByText, queryByText } = yield* render(<SafeComponent />);
+
+      assert.isDefined(yield* getByText("network-error"));
+      assert.isNull(queryByText("generic-error"));
+    }),
+  );
+
+  it.scoped("unwraps symbol-key props", () =>
+    Effect.gen(function* () {
+      const SymbolKey = Symbol.for("error-boundary-symbol");
+
+      const SymbolComponent = Component.gen(function* (
+        Props: Component.ComponentProps<{ [SymbolKey]: string }>,
+      ) {
+        const props = yield* Props;
+        return <div data-testid="symbol-prop">{props[SymbolKey]}</div>;
+      });
+
+      const valueSignal = Signal.unsafeMake("symbol-value");
+      const builder = ErrorBoundary.catch(SymbolComponent);
+      const SafeComponent = yield* builder.catchAll(() => <div>fallback</div>);
+
+      const element = SafeComponent({ [SymbolKey]: valueSignal });
+      const { getByTestId } = yield* render(element);
+      const node = yield* getByTestId("symbol-prop");
+
+      assert.strictEqual(node.textContent, "symbol-value");
+    }),
+  );
+});
+
+// =============================================================================
+// Builder validation
+// =============================================================================
+
+describe("ErrorBoundary builder validation", () => {
+  it.scoped("calling catchAll multiple times yields BuilderError", () =>
+    Effect.gen(function* () {
+      const FailingComponent = Component.gen(function* () {
+        yield* new TestError();
+        return <div />;
+      });
+
+      const TestErrorView = Component.gen(function* (
+        Props: Component.ComponentProps<{ error: TestError }>,
+      ) {
+        yield* Props;
+        return <div>test-error</div>;
+      });
+
+      const builder = ErrorBoundary.catch(FailingComponent)
+        .on("TestError", TestErrorView);
+
+      // First catchAll should succeed
+      yield* builder.catchAll(() => <div>fallback1</div>);
+
+      // Second catchAll should fail with catchAll-multiple
+      const exit = yield* Effect.exit(
+        builder.catchAll(() => <div>fallback2</div>),
+      );
+
+      assert.isTrue(Exit.isFailure(exit));
+      if (Exit.isFailure(exit)) {
+        const error = Cause.squash(exit.cause);
+        assert.isTrue(error instanceof ErrorBoundary.BuilderError);
+        if (error instanceof ErrorBoundary.BuilderError) {
+          assert.strictEqual(error.reason, "catchAll-multiple");
+        }
+      }
+    }),
+  );
+});

--- a/packages/core/src/primitives/error-boundary.ts
+++ b/packages/core/src/primitives/error-boundary.ts
@@ -2,25 +2,34 @@
  * @since 1.0.0
  * ErrorBoundary - Effect-native error handling with pattern matching
  *
- * Provides functional composition for error handling, similar to Resource.match.
- * Wraps components with error boundaries that catch errors and render fallback UIs.
+ * Provides chainable builder API for error handling. Wraps components with
+ * error boundaries that catch errors and render fallback UIs.
+ *
+ * Handlers return Elements (JSX). Effects are wrapped internally.
  *
  * @example
  * ```tsx
- * // With catchAll for flexible matching
- * const SafeComponent = yield* ErrorBoundary.catch(RiskyComponent)
- *   .on("NetworkError", (cause) => <NetworkErrorView cause={cause} />)
+ * // With catchAll for non-exhaustive matching
+ * const SafeComponent = yield* ErrorBoundary
+ *   .catch(RiskyComponent)
+ *   .on("NetworkError", NetworkErrorView)
  *   .catchAll((cause) => <GenericError cause={cause} />)
+ *
+ * // With exhaustive matching (all errors handled)
+ * const SafeComponent = yield* ErrorBoundary
+ *   .catch(RiskyComponent)
+ *   .on("NetworkError", NetworkErrorView)
+ *   .on("ValidationError", ValidationErrorView)
+ *   .exhaustive()
  *
  * return <SafeComponent userId={userId} />
  * ```
  */
-import { Cause, Effect, Scope, Context } from "effect";
+import { Cause, Data, Effect } from "effect";
 import { Component, tagComponent } from "./component.js";
 import {
   type Element,
   Element as ElementEnum,
-  type ElementWithRequirements,
   componentElement,
 } from "./element.js";
 import * as Signal from "./signal.js";
@@ -30,216 +39,388 @@ import type { SignalOrValue } from "./resource.js";
 // Types
 // =============================================================================
 
-/**
- * Error handler function type - receives Cause and returns Element.
- * @since 1.0.0
- */
-export type ErrorHandler<E = unknown, R = never> = (
-  cause: Cause.Cause<E>,
-) => ElementWithRequirements<R>;
+type ErrorForTag<E, Tag extends ErrorTags<E>> = Extract<E, { readonly _tag: Tag }>;
 
 /**
- * Internal error handler type that accepts any cause.
+ * CatchAll handler function type.
  * @internal
  */
-type AnyErrorHandler = (cause: Cause.Cause<unknown>) => Element;
+export type CatchAllHandler<E> = (cause: Cause.Cause<unknown>) => Element;
 
 /**
  * Union of error tags from an error type.
- * Returns string when error type is unknown or has no _tag.
  * @internal
  */
 type ErrorTags<E> = E extends { _tag: infer Tag } ? (Tag extends string ? Tag : string) : string;
 
 /**
- * Normalize requirements type - converts unknown to never.
+ * Union of all known error tags from an error type.
  * @internal
  */
-type NormalizeRequirements<R> = unknown extends R ? never : R;
+type AllErrorTags<E> = E extends { _tag: infer Tag } ? (Tag extends string ? Tag : string) : string;
+
+/**
+ * Remaining tags after handling.
+ * @internal
+ */
+type RemainingTags<E, HandledTags extends string> = Exclude<AllErrorTags<E>, HandledTags>;
+
 
 /**
  * Transform component props to accept SignalOrValue for each field.
- * This allows wrapped components to accept reactive signals as props.
  * @internal
  */
 type ReactiveProps<P> = { readonly [K in keyof P]: SignalOrValue<P[K]> };
 
-// =============================================================================
-// Builder State
-// =============================================================================
+type PropsOutput<Props extends object> = [Props] extends [never] ? {} : Props;
+type PropsInput<Props extends object> = ReactiveProps<PropsOutput<Props>>;
+type PropsKey<Props extends object> = Extract<keyof PropsOutput<Props>, string | symbol>;
+type PropsValue<Props extends object> = PropsOutput<Props>[PropsKey<Props>];
 
 /**
- * Internal mutable state for the error boundary builder.
- * Shared across all builders in a chain to track if catchAll was called.
- * @internal
+ * Errors that can occur during error boundary building.
+ * @since 1.0.0
  */
-interface BuilderState {
-  handlers: Map<string, AnyErrorHandler>;
-  handlerRequirements: Array<Context.Tag<any, any>>;
+export class BuilderError extends Data.TaggedError("BuilderError")<{
+  readonly reason: "duplicate-handler" | "catchAll-multiple" | "on-after-catchAll";
+  readonly tag?: string;
+}> {}
+
+/**
+ * Error when unhandled errors remain at render time.
+ * @since 1.0.0
+ */
+export class UnhandledErrorsError extends Data.TaggedError("UnhandledErrorsError")<{
+  readonly unhandledTags: ReadonlyArray<string>;
+}> {}
+
+// =============================================================================
+// Builder State (Mutable, per instance)
+// =============================================================================
+
+interface BuilderState<E> {
+  handlers: Map<string, (error: unknown, cause: Cause.Cause<unknown>) => Element>;
+  error: BuilderError | null;
   hasCatchAll: boolean;
 }
 
-/**
- * Create initial builder state.
- * @internal
- */
-const createState = (): BuilderState => ({
+const createState = <E>(): BuilderState<E> => ({
   handlers: new Map(),
-  handlerRequirements: [],
+  error: null,
   hasCatchAll: false,
 });
 
 // =============================================================================
-// ErrorBoundary Builder Interface
+// Helpers
 // =============================================================================
 
-/**
- * Error boundary builder with .on() and .catchAll() methods.
- *
- * @since 1.0.0
- */
-export interface ErrorBoundaryBuilder<Props, E, R, RHandlers = never> {
-  /**
-   * Add a handler for a specific error tag.
-   * Cannot be called after catchAll, and cannot add duplicate handlers.
-   *
-   * @since 1.0.0
-   */
+const isTaggedError = (value: unknown): value is { readonly _tag: string } => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const tag = Reflect.get(value, "_tag");
+  return typeof tag === "string";
+};
+
+const isErrorTag = <E, Tag extends ErrorTags<E>>(
+  tag: Tag,
+  error: unknown,
+): error is ErrorForTag<E, Tag> => isTaggedError(error) && error._tag === tag;
+
+const isSignalValue = <A>(value: SignalOrValue<A>): value is Signal.Signal<A> =>
+  Signal.isSignal(value);
+
+const unwrapSignalValue = <A>(value: SignalOrValue<A>): Effect.Effect<A> =>
+  isSignalValue(value) ? Signal.get(value) : Effect.succeed(value);
+
+const isPropKey = <Props extends object>(
+  key: PropertyKey,
+  props: PropsInput<Props>,
+): key is PropsKey<Props> => key in props;
+
+const hasAllProps = <Props extends object>(
+  value: Partial<Props>,
+  keys: ReadonlyArray<keyof Props>,
+): value is Props => keys.every((key) => Object.prototype.hasOwnProperty.call(value, key));
+
+const unhandledErrorElement = (cause: Cause.Cause<unknown>): Element =>
+  componentElement(() =>
+    Effect.gen(function* () {
+      const message = String(Cause.squash(cause));
+      return yield* new UnhandledErrorsError({
+        unhandledTags: [message],
+      });
+    }),
+  );
+
+// =============================================================================
+// Builder Interface
+// =============================================================================
+
+interface ErrorBoundaryBuilderBase<
+  Props extends object,
+  E,
+  R,
+  RHandlers,
+  HandledTags extends string,
+> {
   on<Tag extends ErrorTags<E>, RHandler>(
     tag: Tag,
-    handler: ErrorHandler<E, RHandler>,
-  ): ErrorBoundaryBuilder<Props, E, R, RHandlers | NormalizeRequirements<RHandler>>;
+    component: Component.Type<{ error: ErrorForTag<E, Tag> }, any, RHandler>,
+  ): ErrorBoundaryBuilder<Props, E, R, RHandlers | RHandler, HandledTags | Tag>;
 
-  /**
-   * Add a catch-all handler for any remaining errors.
-   * Finalizes the builder and returns the wrapped component.
-   *
-   * The wrapped component accepts SignalOrValue for all props, enabling
-   * fine-grained reactivity when passing signals to error-boundary-wrapped
-   * components.
-   *
-   * @since 1.0.0
-   */
-  catchAll<RHandler>(
-    handler: ErrorHandler<E, RHandler>,
+  catchAll(
+    handler: CatchAllHandler<E>,
+  ): Effect.Effect<Component.Type<ReactiveProps<Props>, never, R | RHandlers>, BuilderError>;
+
+  exhaustive(
+    this: [RemainingTags<E, HandledTags>] extends [never]
+      ? ErrorBoundaryBuilderImpl<Props, E, R, RHandlers, HandledTags>
+      : never,
   ): Effect.Effect<
-    Component.Type<ReactiveProps<Props>, never, R | RHandlers | NormalizeRequirements<RHandler>>,
-    never,
-    Scope.Scope
+    Component.Type<ReactiveProps<Props>, never, R | RHandlers>,
+    BuilderError | UnhandledErrorsError
   >;
 }
+
+export type ErrorBoundaryBuilder<
+  Props extends object,
+  E,
+  R,
+  RHandlers = never,
+  HandledTags extends string = never,
+> = ErrorBoundaryBuilderBase<Props, E, R, RHandlers, HandledTags>;
 
 // =============================================================================
 // Builder Implementation
 // =============================================================================
 
-/**
- * Create a builder implementation for a component.
- * @internal
- */
-function createBuilder<Props, E, R, RHandlers = never>(
-  component: Component.Type<Props, E, R>,
-  state: BuilderState,
-): ErrorBoundaryBuilder<Props, E, R, RHandlers> {
-  return {
-    on: <RHandler>(
-      tag: string,
-      handler: ErrorHandler<E, RHandler>,
-    ): ErrorBoundaryBuilder<Props, E, R, RHandlers | NormalizeRequirements<RHandler>> => {
-      if (state.hasCatchAll) {
-        throw new Error("Cannot add .on() handler after .catchAll()");
-      }
-      if (state.handlers.has(tag)) {
-        throw new Error(`Duplicate handler for error tag: ${tag}`);
-      }
+class ErrorBoundaryBuilderImpl<
+  Props extends object,
+  E,
+  R,
+  RHandlers,
+  HandledTags extends string,
+> implements ErrorBoundaryBuilderBase<Props, E, R, RHandlers, HandledTags>
+{
+  constructor(
+    private readonly component: Component.Type<Props, E, R>,
+    private readonly state: BuilderState<E>,
+  ) {}
 
-      // Mutate shared state
-      state.handlers.set(tag, handler as AnyErrorHandler);
-
-      return createBuilder<Props, E, R, RHandlers | NormalizeRequirements<RHandler>>(
-        component,
-        state,
+  on<Tag extends ErrorTags<E>, RHandler>(
+    tag: Tag,
+    component: Component.Type<{ error: ErrorForTag<E, Tag> }, any, RHandler>,
+  ): ErrorBoundaryBuilder<Props, E, R, RHandlers | RHandler, HandledTags | Tag> {
+    if (this.state.hasCatchAll) {
+      const nextState = this.withError(new BuilderError({ reason: "on-after-catchAll" }));
+      return new ErrorBoundaryBuilderImpl<
+        Props,
+        E,
+        R,
+        RHandlers | RHandler,
+        HandledTags | Tag
+      >(
+        this.component,
+        nextState,
       );
-    },
+    }
 
-    catchAll: <RHandler>(
-      handler: ErrorHandler<E, RHandler>,
-    ): Effect.Effect<
-      Component.Type<ReactiveProps<Props>, never, R | RHandlers | NormalizeRequirements<RHandler>>,
-      never,
-      Scope.Scope
-    > => {
-      if (state.hasCatchAll) {
-        throw new Error("Cannot call .catchAll() multiple times");
+    if (this.state.handlers.has(tag)) {
+      const nextState = this.withError(new BuilderError({ reason: "duplicate-handler", tag }));
+      return new ErrorBoundaryBuilderImpl<
+        Props,
+        E,
+        R,
+        RHandlers | RHandler,
+        HandledTags | Tag
+      >(
+        this.component,
+        nextState,
+      );
+    }
+
+    const handlers = new Map(this.state.handlers);
+    const handle = (error: unknown, cause: Cause.Cause<unknown>): Element => {
+      if (isErrorTag<E, Tag>(tag, error)) {
+        return component({ error });
       }
+      return unhandledErrorElement(cause);
+    };
+    handlers.set(tag, handle);
 
-      // Mark that catchAll has been called
-      state.hasCatchAll = true;
+    const nextState: BuilderState<E> = {
+      handlers,
+      error: this.state.error,
+      hasCatchAll: this.state.hasCatchAll,
+    };
 
-      return Effect.gen(function* () {
-        const fallbackHandler: ErrorHandler = (cause: Cause.Cause<unknown>): Element => {
-          const error = Cause.squash(cause);
+    return new ErrorBoundaryBuilderImpl<
+      Props,
+      E,
+      R,
+      RHandlers | RHandler,
+      HandledTags | Tag
+    >(
+      this.component,
+      nextState,
+    );
+  }
 
-          // Check if error has a _tag for pattern matching
-          if (typeof error === "object" && error !== null && "_tag" in error) {
-            const tag = (error as { _tag: string })._tag;
-            const specificHandler = state.handlers.get(tag);
-            if (specificHandler !== undefined) {
-              return specificHandler(cause as Cause.Cause<E>);
-            }
+  catchAll(
+    handler: CatchAllHandler<E>,
+  ): Effect.Effect<Component.Type<ReactiveProps<Props>, never, R | RHandlers>, BuilderError> {
+    // Validate and mutate state synchronously before entering Effect context
+    if (this.state.error !== null) {
+      const error = this.state.error;
+      return Effect.gen(this, function* () {
+        return yield* error;
+      });
+    }
+    if (this.state.hasCatchAll) {
+      return Effect.gen(this, function* () {
+        return yield* new BuilderError({ reason: "catchAll-multiple" });
+      });
+    }
+    this.state.hasCatchAll = true;
+
+    return Effect.gen(this, function* () {
+      const fallbackHandler = (
+        cause: Cause.Cause<unknown>,
+      ): Effect.Effect<Element, never, unknown> =>
+        Effect.succeed(this.resolveHandler(handler, cause));
+
+      return yield* this.buildComponent(fallbackHandler);
+    });
+  }
+
+  exhaustive(
+    this: [RemainingTags<E, HandledTags>] extends [never]
+      ? ErrorBoundaryBuilderImpl<Props, E, R, RHandlers, HandledTags>
+      : never,
+  ): Effect.Effect<
+    Component.Type<ReactiveProps<Props>, never, R | RHandlers>,
+    BuilderError | UnhandledErrorsError
+  > {
+    // Validate and mutate state synchronously before entering Effect context
+    if (this.state.error !== null) {
+      const error = this.state.error;
+      return Effect.gen(this, function* () {
+        return yield* error;
+      });
+    }
+    if (this.state.hasCatchAll) {
+      return Effect.gen(this, function* () {
+        return yield* new BuilderError({ reason: "catchAll-multiple" });
+      });
+    }
+    this.state.hasCatchAll = true;
+
+    return Effect.gen(this, function* () {
+      const fallbackHandler = (
+        cause: Cause.Cause<unknown>,
+      ): Effect.Effect<Element, never, unknown> =>
+        Effect.succeed(this.resolveExhaustiveHandler(cause));
+
+      return yield* this.buildComponent(fallbackHandler);
+    });
+  }
+
+  private withError(error: BuilderError): BuilderState<E> {
+    if (this.state.error !== null) {
+      return this.state;
+    }
+
+    return {
+      handlers: this.state.handlers,
+      error,
+      hasCatchAll: this.state.hasCatchAll,
+    };
+  }
+
+  private resolveHandler(
+    catchAllHandler: CatchAllHandler<E>,
+    cause: Cause.Cause<unknown>,
+  ): Element {
+    const error = Cause.squash(cause);
+
+    if (isTaggedError(error)) {
+      const specificHandler = this.state.handlers.get(error._tag);
+      if (specificHandler !== undefined) {
+        return specificHandler(error, cause);
+      }
+    }
+
+    return catchAllHandler(cause);
+  }
+
+  private resolveExhaustiveHandler(cause: Cause.Cause<unknown>): Element {
+    const error = Cause.squash(cause);
+
+    if (isTaggedError(error)) {
+      const specificHandler = this.state.handlers.get(error._tag);
+      if (specificHandler !== undefined) {
+        return specificHandler(error, cause);
+      }
+    }
+
+    return unhandledErrorElement(cause);
+  }
+
+  private buildComponent(
+    fallbackHandler: (cause: Cause.Cause<unknown>) => Effect.Effect<Element, never, unknown>,
+  ): Effect.Effect<Component.Type<ReactiveProps<Props>, never, R>, never> {
+    return Effect.sync(() => {
+      const component = this.component;
+      const safeComponentRunFn = (
+        _props: PropsInput<Props>,
+      ): Effect.Effect<Element, never, R> =>
+        Effect.gen(function* () {
+          const propKeys = Reflect.ownKeys(_props).filter((key): key is PropsKey<Props> =>
+            isPropKey<Props>(key, _props),
+          );
+
+          const entries = yield* Effect.forEach(
+            propKeys,
+            (key): Effect.Effect<[PropsKey<Props>, PropsValue<Props>], never> =>
+              Effect.gen(function* () {
+                const value: SignalOrValue<PropsValue<Props>> = _props[key];
+                const resolved = yield* unwrapSignalValue(value);
+                return [key, resolved];
+              }),
+            { concurrency: "inherit" },
+          );
+
+          const unwrappedProps: Partial<PropsOutput<Props>> = {};
+          for (const [key, value] of entries) {
+            unwrappedProps[key] = value;
           }
 
-          // Fall back to catch-all handler
-          return handler(cause as Cause.Cause<E>);
-        };
+          if (!hasAllProps<PropsOutput<Props>>(unwrappedProps, propKeys)) {
+            return ElementEnum.Text({ content: "Error: props incomplete" });
+          }
 
-        // Get the original component's metadata
-        const originalLayers = (component as any)._layers || [];
-        const originalRequirements = (component as any)._requirements || [];
+          const childElement = component(unwrappedProps);
+          return ElementEnum.ErrorBoundaryElement({
+            child: childElement,
+            fallback: fallbackHandler,
+            onError: null,
+          });
+        });
 
-        // Create a component that wraps the original with error boundary
-        // Accepts ReactiveProps to allow SignalOrValue for fine-grained reactivity
-        const safeComponentFn = (
-          _props: [Props] extends [never] ? {} : ReactiveProps<Props>,
-        ): Element => {
-          // Unwrap signals from props before passing to the original component
-          const run = (): Effect.Effect<Element, never, R> =>
-            Effect.gen(function* () {
-              const unwrappedProps: Record<string, unknown> = {};
-              for (const key of Object.keys(_props as Record<string, unknown>)) {
-                const value = (_props as Record<string, unknown>)[key];
-                if (Signal.isSignal(value)) {
-                  unwrappedProps[key] = yield* Signal.get(value);
-                } else {
-                  unwrappedProps[key] = value;
-                }
-              }
-              // Call the original component with unwrapped props
-              const childElement = component(
-                unwrappedProps as [Props] extends [never] ? {} : Props,
-              );
-              return ElementEnum.ErrorBoundaryElement({
-                child: childElement,
-                fallback: fallbackHandler,
-                onError: null,
-              });
-            });
+      const safeComponentFn = (_props: PropsInput<Props>): Element =>
+        componentElement(() => safeComponentRunFn(_props));
 
-          return componentElement(run);
-        };
+      const safeComponent: Component.Type<ReactiveProps<Props>, never, R> = tagComponent(
+        safeComponentFn,
+        this.component._layers,
+        this.component._requirements,
+        safeComponentRunFn,
+      );
 
-        // Use tagComponent to create a proper Component.Type with working .provide()
-        // Explicitly specify ReactiveProps<Props> to allow SignalOrValue in props
-        const safeComponent = tagComponent<
-          ReactiveProps<Props>,
-          never,
-          R | RHandlers | NormalizeRequirements<RHandler>
-        >(safeComponentFn, originalLayers, [...originalRequirements, ...state.handlerRequirements]);
-
-        return safeComponent;
-      });
-    },
-  };
+      return safeComponent;
+    });
+  }
 }
 
 // =============================================================================
@@ -249,26 +430,15 @@ function createBuilder<Props, E, R, RHandlers = never>(
 /**
  * Create an error boundary builder for a component.
  *
- * Returns a builder that tracks which error cases have been handled.
- * The builder must be completed with .catchAll() to finalize.
- *
- * @example
- * ```tsx
- * // With catchAll
- * const SafeComponent = yield* ErrorBoundary.catch(RiskyComponent)
- *   .on("NetworkError", (cause) => <NetworkErrorView cause={cause} />)
- *   .catchAll((cause) => <GenericError cause={cause} />)
- *
- * return <SafeComponent userId={userId} />
- * ```
+ * Returns a synchronous builder - no yield* needed to start chaining.
+ * Finalize with .catchAll() or .exhaustive() when done.
  *
  * @since 1.0.0
  */
-export function catch_<Props, E, R>(
+export function catch_<Props extends object, E, R>(
   component: Component.Type<Props, E, R>,
-): ErrorBoundaryBuilder<Props, E, R> {
-  const state = createState();
-  return createBuilder<Props, E, R>(component, state);
+): ErrorBoundaryBuilder<Props, E, R, never, never> {
+  return new ErrorBoundaryBuilderImpl<Props, E, R, never, never>(component, createState<E>());
 }
 
 // Export catch_ as catch (reserved word workaround)


### PR DESCRIPTION
## Summary
- switch ErrorBoundary .on to handler components w/ { error } prop for R inference
- fix catchAll/exhaustive state mutation ordering; add catchAll-multiple test
- update tests/examples; add opencode config + ignore .overseer