### PR TITLE
chore: apply release check formatting

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -88,7 +88,6 @@ export default Component.gen(function* () {
 
         {/* JSON-LD */}
         <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-
       </head>
       <body>
         <Router.Outlet />

--- a/packages/core/src/__tests__/jsx-completions.test.ts
+++ b/packages/core/src/__tests__/jsx-completions.test.ts
@@ -13,7 +13,7 @@ const Svg = Component.gen(function* () {
 });
 `;
 
-const completionNamesFor = (tag: "div" | "svg"): ReadonlySet<string> => {
+const completionsForTags = (): ReadonlyMap<"div" | "svg", ReadonlySet<string>> => {
   const root = process.cwd();
   const fileName = path.join(root, "src", "__completion-repro.tsx");
   const files = new Map<string, { readonly version: string; readonly text: string }>([
@@ -58,16 +58,21 @@ const completionNamesFor = (tag: "div" | "svg"): ReadonlySet<string> => {
   };
 
   const service = ts.createLanguageService(host);
-  const marker = `<${tag} vi`;
-  const position = source.indexOf(marker) + marker.length;
-  const completions = service.getCompletionsAtPosition(fileName, position, {});
-  return new Set(completions?.entries.map((entry) => entry.name) ?? []);
+  return new Map(
+    (["div", "svg"] as const).map((tag) => {
+      const marker = `<${tag} vi`;
+      const position = source.indexOf(marker) + marker.length;
+      const completions = service.getCompletionsAtPosition(fileName, position, {});
+      return [tag, new Set(completions?.entries.map((entry) => entry.name) ?? [])];
+    }),
+  );
 };
 
 describe("JSX intrinsic completions", () => {
   it("does not offer SVG props on HTML elements", () => {
-    const divNames = completionNamesFor("div");
-    const svgNames = completionNamesFor("svg");
+    const completions = completionsForTags();
+    const divNames = completions.get("div") ?? new Set<string>();
+    const svgNames = completions.get("svg") ?? new Set<string>();
 
     assert.isFalse(divNames.has("viewBox"));
     assert.isFalse(divNames.has("strokeWidth"));

--- a/packages/core/src/primitives/__tests__/render-keyed-list.test.tsx
+++ b/packages/core/src/primitives/__tests__/render-keyed-list.test.tsx
@@ -25,13 +25,16 @@ describe("renderKeyedList", () => {
         <div>
           {Signal.each(
             items,
-            (item) => <span data-id={item}>{item}</span>,
+            (item) => (
+              <span data-id={item}>{item}</span>
+            ),
             { key: (item) => item },
           )}
         </div>,
       );
 
-      const ids = () => Array.from(container.querySelectorAll("[data-id]")).map((el) => el.textContent);
+      const ids = () =>
+        Array.from(container.querySelectorAll("[data-id]")).map((el) => el.textContent);
 
       assert.deepEqual(ids(), []);
 
@@ -56,7 +59,9 @@ describe("renderKeyedList", () => {
         <div>
           {Signal.each(
             items,
-            (item) => <span data-id={item}>{item}</span>,
+            (item) => (
+              <span data-id={item}>{item}</span>
+            ),
             { key: (item) => item },
           )}
         </div>,

--- a/packages/core/src/primitives/__tests__/render-portal.test.tsx
+++ b/packages/core/src/primitives/__tests__/render-portal.test.tsx
@@ -13,7 +13,9 @@ describe("render-portal", () => {
       yield* Effect.addFinalizer(() => Effect.sync(() => target.remove()));
 
       const { getByTestId } = yield* render(
-        <div data-testid="host">{Element.Portal({ target, children: <span>teleported</span> })}</div>,
+        <div data-testid="host">
+          {Element.Portal({ target, children: <span>teleported</span> })}
+        </div>,
       );
 
       assert.strictEqual((yield* getByTestId("host")).textContent, "");

--- a/packages/core/src/primitives/__tests__/renderer.test.tsx
+++ b/packages/core/src/primitives/__tests__/renderer.test.tsx
@@ -785,13 +785,13 @@ describe("Props application", () => {
 
   scoped("should reject SVG-only props on HTML elements at typecheck", () =>
     Effect.sync(() => {
-      void <svg viewBox="0 0 24 24" strokeWidth="2" />;
+      void (<svg viewBox="0 0 24 24" strokeWidth="2" />);
 
       // @ts-expect-error viewBox is SVG-only.
-      void <div viewBox="0 0 24 24" />;
+      void (<div viewBox="0 0 24 24" />);
 
       // @ts-expect-error strokeWidth is SVG-only.
-      void <button strokeWidth="2" />;
+      void (<button strokeWidth="2" />);
     }),
   );
 

--- a/packages/core/src/primitives/element.ts
+++ b/packages/core/src/primitives/element.ts
@@ -175,6 +175,15 @@ export interface CommonProps {
 /**
  * Backward-compatible alias for common intrinsic props.
  *
+ * @remarks
+ * `BaseProps` is retained for callers that imported the original shared
+ * intrinsic prop surface before `HtmlProps` and `SvgProps` were split.
+ *
+ * @example
+ * ```ts
+ * const props: BaseProps = { id: "root", className: "app" }
+ * ```
+ *
  * @category Elements
  * @public
  * @since 1.0.0
@@ -312,6 +321,16 @@ export interface HtmlProps extends CommonProps, EventProps {
 /**
  * Props for intrinsic SVG elements.
  *
+ * @remarks
+ * `SvgProps` is the shared prop shape used by known SVG intrinsic elements.
+ * It includes SVG-only attributes such as `viewBox` and `strokeWidth` that are
+ * intentionally not accepted by known HTML intrinsic elements.
+ *
+ * @example
+ * ```ts
+ * const props: SvgProps = { viewBox: "0 0 24 24", strokeWidth: 2 }
+ * ```
+ *
  * @category Elements
  * @public
  * @since 1.0.0
@@ -346,6 +365,11 @@ export interface SvgProps extends CommonProps, EventProps {
  * Kept as the broad low-level prop shape used by the element model and JSX
  * runtime bridge. JSX tag validation uses `IntrinsicElements` so known HTML
  * tags do not accept SVG-only props.
+ *
+ * @example
+ * ```ts
+ * const props: ElementProps = { id: "icon", viewBox: "0 0 24 24" }
+ * ```
  *
  * @category Elements
  * @public
@@ -598,9 +622,7 @@ export interface CustomIntrinsicElements {
 }
 
 export interface IntrinsicElements
-  extends HtmlIntrinsicElements,
-    SvgIntrinsicElements,
-    CustomIntrinsicElements {}
+  extends HtmlIntrinsicElements, SvgIntrinsicElements, CustomIntrinsicElements {}
 
 /**
  * Virtual DOM Element - the core type of trygg

--- a/packages/core/src/primitives/render-error-boundary.ts
+++ b/packages/core/src/primitives/render-error-boundary.ts
@@ -94,7 +94,13 @@ export const renderErrorBoundary = (
 
         const fallbackScope = yield* Scope.fork(yield* Effect.scope);
         const fallbackResult = yield* deps
-          .renderElement(fallbackElement, renderParent, renderContext, context, deps.defaultRenderOptions)
+          .renderElement(
+            fallbackElement,
+            renderParent,
+            renderContext,
+            context,
+            deps.defaultRenderOptions,
+          )
           .pipe(
             Scope.provide(fallbackScope),
             Effect.onError(() => Scope.close(fallbackScope, Exit.void)),
@@ -170,9 +176,7 @@ export const renderErrorBoundary = (
       .pipe(
         Scope.provide(childScope),
         Effect.onError(() => Scope.close(childScope, Exit.void)),
-        Effect.map(
-          (result): ChildRenderResult => ({ success: true, result, scope: childScope }),
-        ),
+        Effect.map((result): ChildRenderResult => ({ success: true, result, scope: childScope })),
         Effect.catchCause((cause) =>
           renderFallbackForError(cause).pipe(
             Effect.map((): ChildRenderResult => ({ success: false })),

--- a/packages/core/src/primitives/render-keyed-list.ts
+++ b/packages/core/src/primitives/render-keyed-list.ts
@@ -80,564 +80,556 @@ export const renderKeyedList = (
   deps: RenderKeyedListDeps,
 ): Effect.Effect<RenderResult, unknown, unknown> =>
   Effect.gen(function* () {
-  // Create anchor comment for the list
-  const anchor = document.createComment("keyed-list");
-  parent.appendChild(anchor);
+    // Create anchor comment for the list
+    const anchor = document.createComment("keyed-list");
+    parent.appendChild(anchor);
 
-  // Track item states by key
-  type ItemState = {
-    renderPhase: Signal.RenderPhase;
-    result: RenderResult;
-    /** Comment marking start of this item's DOM range */
-    startMarker: Comment;
-    /** Comment marking end of this item's DOM range (always after content) */
-    endMarker: Comment;
-    item: unknown;
-    /** Current index in the list (updated on reorder) */
-    currentIndex: number;
-    /** Whether a re-render is in progress */
-    isRerendering: boolean;
-    /** Whether another re-render is pending */
-    pendingRerender: boolean;
-    /** Map from signal debugId to unsubscribe Effect */
-    subscriptions: Map<string, Effect.Effect<void>>;
-    /** Trigger item rerender while preserving scope */
-    scheduleRerender: () => Effect.Effect<void>;
-  };
-  const itemStates = new Map<string | number, ItemState>();
-  const keyOrder: Array<string | number> = [];
-  let isUnmounted = false;
-  let isUpdating = false;
-  let pendingUpdate = false;
+    // Track item states by key
+    type ItemState = {
+      renderPhase: Signal.RenderPhase;
+      result: RenderResult;
+      /** Comment marking start of this item's DOM range */
+      startMarker: Comment;
+      /** Comment marking end of this item's DOM range (always after content) */
+      endMarker: Comment;
+      item: unknown;
+      /** Current index in the list (updated on reorder) */
+      currentIndex: number;
+      /** Whether a re-render is in progress */
+      isRerendering: boolean;
+      /** Whether another re-render is pending */
+      pendingRerender: boolean;
+      /** Map from signal debugId to unsubscribe Effect */
+      subscriptions: Map<string, Effect.Effect<void>>;
+      /** Trigger item rerender while preserving scope */
+      scheduleRerender: () => Effect.Effect<void>;
+    };
+    const itemStates = new Map<string | number, ItemState>();
+    const keyOrder: Array<string | number> = [];
+    let isUnmounted = false;
+    let isUpdating = false;
+    let pendingUpdate = false;
 
-  // Helper to render a single item with a stable render phase
-  const renderItem = Effect.fn("renderItem")(function* (
-    item: unknown,
-    index: number,
-    existingPhase: Signal.RenderPhase | null,
-    parentOverride?: Node,
-  ) {
-    // Use existing phase or create new one
-    const renderPhase = existingPhase ?? (yield* Signal.makeRenderPhase);
+    // Helper to render a single item with a stable render phase
+    const renderItem = Effect.fn("renderItem")(function* (
+      item: unknown,
+      index: number,
+      existingPhase: Signal.RenderPhase | null,
+      parentOverride?: Node,
+    ) {
+      // Use existing phase or create new one
+      const renderPhase = existingPhase ?? (yield* Signal.makeRenderPhase);
 
-    if (existingPhase !== null) {
-      // Reset for re-render
-      yield* Signal.resetRenderPhase(renderPhase);
-    }
-
-    // Execute render function with render phase context and parent context
-    const renderEffect = deps.provideRenderContext(renderFn(item, index), runtime, context);
-
-    const element = yield* Effect.provideService(
-      renderEffect,
-      Signal.CurrentRenderPhase,
-      renderPhase,
-    );
-
-    const listParent = parentOverride ?? anchor.parentNode ?? parent;
-
-    // Insert start marker before rendering so content appears after it
-    const startMarker = document.createComment("item-start");
-    listParent.appendChild(startMarker);
-
-    // Render into list parent (content appended after startMarker)
-    const normalizedElement = yield* Element.fromUnknown(element);
-    const result = yield* deps.renderElement(
-      normalizedElement,
-      listParent,
-      runtime,
-      context,
-      options,
-    );
-
-    // Insert end marker after content - ensures moveRange captures full Fragment range
-    const endMarker = document.createComment("item-end");
-    listParent.appendChild(endMarker);
-
-    return { renderPhase, result, startMarker, endMarker };
-  });
-
-  /**
-   * Diff subscriptions: unsubscribe from removed signals, subscribe to new ones.
-   * Reuses existing subscriptions for signals that are still accessed.
-   * @internal
-   */
-  const diffSubscriptions: (
-    key: string | number,
-    state: ItemState,
-    newAccessed: Set<Signal.Signal<unknown>>,
-    scheduleRerender: () => Effect.Effect<void>,
-  ) => Effect.Effect<void> = Effect.fnUntraced(function* (
-    key: string | number,
-    state: ItemState,
-    newAccessed: Set<Signal.Signal<unknown>>,
-    scheduleRerender: () => Effect.Effect<void>,
-  ) {
-    const oldSubs = state.subscriptions;
-    const newSubs = new Map<string, Effect.Effect<void>>();
-
-    // Build set of new signal IDs
-    const newSignalIds = new Set<string>();
-    for (const signal of newAccessed) {
-      newSignalIds.add(signal._debugId);
-    }
-
-    // Unsubscribe from signals no longer accessed
-    for (const [signalId, unsubscribe] of oldSubs) {
-      if (!newSignalIds.has(signalId)) {
-        yield* unsubscribe;
-        yield* Debug.log({
-          event: "render.keyedlist.subscription.remove",
-          key,
-          signal_id: signalId,
-        });
+      if (existingPhase !== null) {
+        // Reset for re-render
+        yield* Signal.resetRenderPhase(renderPhase);
       }
-    }
 
-    // Subscribe to new signals, reuse existing subscriptions
-    for (const signal of newAccessed) {
-      const existingUnsub = oldSubs.get(signal._debugId);
-      if (existingUnsub !== undefined) {
-        // Reuse existing subscription
-        newSubs.set(signal._debugId, existingUnsub);
-      } else {
-        // New subscription needed
-        const unsubscribe = yield* Signal.subscribe(signal, scheduleRerender);
-        newSubs.set(signal._debugId, unsubscribe);
-        yield* Debug.log({
-          event: "render.keyedlist.subscription.add",
-          key,
-          signal_id: signal._debugId,
-        });
+      // Execute render function with render phase context and parent context
+      const renderEffect = deps.provideRenderContext(renderFn(item, index), runtime, context);
+
+      const element = yield* Effect.provideService(
+        renderEffect,
+        Signal.CurrentRenderPhase,
+        renderPhase,
+      );
+
+      const listParent = parentOverride ?? anchor.parentNode ?? parent;
+
+      // Insert start marker before rendering so content appears after it
+      const startMarker = document.createComment("item-start");
+      listParent.appendChild(startMarker);
+
+      // Render into list parent (content appended after startMarker)
+      const normalizedElement = yield* Element.fromUnknown(element);
+      const result = yield* deps.renderElement(
+        normalizedElement,
+        listParent,
+        runtime,
+        context,
+        options,
+      );
+
+      // Insert end marker after content - ensures moveRange captures full Fragment range
+      const endMarker = document.createComment("item-end");
+      listParent.appendChild(endMarker);
+
+      return { renderPhase, result, startMarker, endMarker };
+    });
+
+    /**
+     * Diff subscriptions: unsubscribe from removed signals, subscribe to new ones.
+     * Reuses existing subscriptions for signals that are still accessed.
+     * @internal
+     */
+    const diffSubscriptions: (
+      key: string | number,
+      state: ItemState,
+      newAccessed: Set<Signal.Signal<unknown>>,
+      scheduleRerender: () => Effect.Effect<void>,
+    ) => Effect.Effect<void> = Effect.fnUntraced(function* (
+      key: string | number,
+      state: ItemState,
+      newAccessed: Set<Signal.Signal<unknown>>,
+      scheduleRerender: () => Effect.Effect<void>,
+    ) {
+      const oldSubs = state.subscriptions;
+      const newSubs = new Map<string, Effect.Effect<void>>();
+
+      // Build set of new signal IDs
+      const newSignalIds = new Set<string>();
+      for (const signal of newAccessed) {
+        newSignalIds.add(signal._debugId);
       }
-    }
 
-    state.subscriptions = newSubs;
-  });
-
-  // Function to update the list
-  // Note: updateList is sync because it's called from signal listener,
-  // but it immediately forks an Effect for the actual work.
-  function updateList(): void {
-    if (isUnmounted) return;
-
-    if (isUpdating) {
-      pendingUpdate = true;
-      return;
-    }
-
-    isUpdating = true;
-
-    deps.runForkInRenderContext(
-      Effect.scoped(
-        Effect.gen(function* () {
+      // Unsubscribe from signals no longer accessed
+      for (const [signalId, unsubscribe] of oldSubs) {
+        if (!newSignalIds.has(signalId)) {
+          yield* unsubscribe;
           yield* Debug.log({
-            event: "render.keyedlist.update",
-            current_keys: keyOrder.length,
+            event: "render.keyedlist.subscription.remove",
+            key,
+            signal_id: signalId,
           });
+        }
+      }
 
+      // Subscribe to new signals, reuse existing subscriptions
+      for (const signal of newAccessed) {
+        const existingUnsub = oldSubs.get(signal._debugId);
+        if (existingUnsub !== undefined) {
+          // Reuse existing subscription
+          newSubs.set(signal._debugId, existingUnsub);
+        } else {
+          // New subscription needed
+          const unsubscribe = yield* Signal.subscribe(signal, scheduleRerender);
+          newSubs.set(signal._debugId, unsubscribe);
           yield* Debug.log({
-            event: "render.keyedlist.state",
-            phase: "start",
-            key_order: [...keyOrder],
+            event: "render.keyedlist.subscription.add",
+            key,
+            signal_id: signal._debugId,
           });
+        }
+      }
 
-          if (isUnmounted || anchor.parentNode === null) {
-            return;
-          }
+      state.subscriptions = newSubs;
+    });
 
-          // Get current items from source signal
-          const items = yield* Signal.get(source);
+    // Function to update the list
+    // Note: updateList is sync because it's called from signal listener,
+    // but it immediately forks an Effect for the actual work.
+    function updateList(): void {
+      if (isUnmounted) return;
 
-          // Compute new keys
-          const newKeys = items.map((item, i) => keyFn(item, i));
-          const newKeySet = new Set(newKeys);
+      if (isUpdating) {
+        pendingUpdate = true;
+        return;
+      }
 
-          yield* Debug.log({
-            event: "render.keyedlist.state",
-            phase: "computed",
-            key_order: [...keyOrder],
-            new_keys: newKeys,
-          });
+      isUpdating = true;
 
-          // Build map of old key -> old index for LIS calculation
-          const oldKeyToIndex = new Map<string | number, number>();
-          for (let i = 0; i < keyOrder.length; i++) {
-            const key = keyOrder[i];
-            if (key !== undefined) {
-              oldKeyToIndex.set(key, i);
+      deps.runForkInRenderContext(
+        Effect.scoped(
+          Effect.gen(function* () {
+            yield* Debug.log({
+              event: "render.keyedlist.update",
+              current_keys: keyOrder.length,
+            });
+
+            yield* Debug.log({
+              event: "render.keyedlist.state",
+              phase: "start",
+              key_order: [...keyOrder],
+            });
+
+            if (isUnmounted || anchor.parentNode === null) {
+              return;
             }
-          }
 
-          // Remove items that are no longer in the list
-          for (const key of keyOrder) {
-            if (!newKeySet.has(key)) {
-              const state = itemStates.get(key);
-              if (state) {
-                // Clean up subscriptions
-                for (const [, unsubscribe] of state.subscriptions) {
-                  yield* unsubscribe;
+            // Get current items from source signal
+            const items = yield* Signal.get(source);
+
+            // Compute new keys
+            const newKeys = items.map((item, i) => keyFn(item, i));
+            const newKeySet = new Set(newKeys);
+
+            yield* Debug.log({
+              event: "render.keyedlist.state",
+              phase: "computed",
+              key_order: [...keyOrder],
+              new_keys: newKeys,
+            });
+
+            // Build map of old key -> old index for LIS calculation
+            const oldKeyToIndex = new Map<string | number, number>();
+            for (let i = 0; i < keyOrder.length; i++) {
+              const key = keyOrder[i];
+              if (key !== undefined) {
+                oldKeyToIndex.set(key, i);
+              }
+            }
+
+            // Remove items that are no longer in the list
+            for (const key of keyOrder) {
+              if (!newKeySet.has(key)) {
+                const state = itemStates.get(key);
+                if (state) {
+                  // Clean up subscriptions
+                  for (const [, unsubscribe] of state.subscriptions) {
+                    yield* unsubscribe;
+                  }
+                  // Clean up rendered content + markers
+                  yield* state.result.cleanup;
+                  state.startMarker.remove();
+                  state.endMarker.remove();
+                  itemStates.delete(key);
+                  yield* Debug.log({
+                    event: "render.keyedlist.item.remove",
+                    key,
+                  });
                 }
-                // Clean up rendered content + markers
-                yield* state.result.cleanup;
-                state.startMarker.remove();
-                state.endMarker.remove();
-                itemStates.delete(key);
+              }
+            }
+
+            // Compute old indices for existing items in new order
+            // -1 means new item (not in old list)
+            const oldIndicesInNewOrder: Array<number> = [];
+            for (const key of newKeys) {
+              if (key === undefined) continue;
+              const oldIndex = oldKeyToIndex.get(key);
+              oldIndicesInNewOrder.push(oldIndex ?? -1);
+            }
+
+            // Filter to only existing items (non-negative indices) for LIS
+            const existingIndices = oldIndicesInNewOrder.filter((i) => i >= 0);
+            const lisIndices = new Set(computeLIS(existingIndices));
+
+            // Track which existing items (by their old index) are in LIS
+            const stableOldIndices = new Set<number>();
+            let lisIdx = 0;
+            for (const oldIdx of existingIndices) {
+              if (lisIndices.has(lisIdx)) {
+                stableOldIndices.add(oldIdx);
+              }
+              lisIdx++;
+            }
+
+            // Render new items and collect all states in new order
+            const stagedParent = document.createDocumentFragment();
+            const newItemStates: Array<{
+              key: string | number;
+              state: ItemState;
+              isNew: boolean;
+              needsMove: boolean;
+              needsRerender: boolean;
+            }> = [];
+
+            for (let i = 0; i < items.length; i++) {
+              const item = items[i];
+              const key = newKeys[i];
+
+              if (key === undefined) continue;
+
+              const existingState = itemStates.get(key);
+              const oldIndex = oldKeyToIndex.get(key);
+
+              if (existingState !== undefined && oldIndex !== undefined) {
+                // Item exists - update stored item reference
+                // If item identity changed, schedule rerender later.
+                const needsRerender = !Object.is(existingState.item, item);
+                existingState.item = item;
+                // Check if this item needs to move (not in LIS)
+                const needsMove = !stableOldIndices.has(oldIndex);
+                newItemStates.push({
+                  key,
+                  state: existingState,
+                  isNew: false,
+                  needsMove,
+                  needsRerender,
+                });
+              } else {
+                // New item - create new state
+                const { renderPhase, result, startMarker, endMarker } = yield* renderItem(
+                  item,
+                  i,
+                  null,
+                  stagedParent,
+                );
+
+                // Set up subscriptions for this item's accessed signals.
+                // scheduleItemRerender returns lightweight Effect.sync to avoid blocking
+                // signal notification chain. Actual re-render forks via Runtime.runFork.
+                // Batching via isRerendering/pendingRerender coalesces rapid updates.
+                const scheduleItemRerender = (): Effect.Effect<void> =>
+                  Effect.sync(() => {
+                    if (isUnmounted) return;
+                    const currentState = itemStates.get(key);
+                    if (currentState === undefined) return;
+
+                    // Coalesce rapid signal changes - mark pending if already rerendering
+                    if (currentState.isRerendering) {
+                      currentState.pendingRerender = true;
+                      return;
+                    }
+                    currentState.isRerendering = true;
+
+                    deps.runForkInRenderContext(
+                      Effect.scoped(
+                        Effect.gen(function* () {
+                          // Re-render with same phase (preserves signals).
+                          // renderItem appends [startMarker, content, endMarker] to listParent.
+                          // We then move the new nodes before the old startMarker and
+                          // clean up the old range to preserve DOM order.
+                          const oldStartMarker = currentState.startMarker;
+                          const oldEndMarker = currentState.endMarker;
+
+                          // Track new nodes for cleanup on error
+                          let newResult: RenderResult | null = null;
+                          let newStartMarker: Comment | null = null;
+                          let newEndMarker: Comment | null = null;
+
+                          yield* Effect.gen(function* () {
+                            const rendered = yield* renderItem(
+                              currentState.item,
+                              currentState.currentIndex,
+                              currentState.renderPhase,
+                            );
+                            newResult = rendered.result;
+                            newStartMarker = rendered.startMarker;
+                            newEndMarker = rendered.endMarker;
+
+                            // Move new range [newStartMarker..newEndMarker] before old start
+                            moveRange(newStartMarker, newEndMarker, oldStartMarker);
+
+                            // Clean up old render (removes old content)
+                            yield* currentState.result.cleanup;
+                            oldStartMarker.remove();
+                            oldEndMarker.remove();
+
+                            // Update state
+                            currentState.result = newResult;
+                            currentState.startMarker = newStartMarker;
+                            currentState.endMarker = newEndMarker;
+
+                            // Check if another re-render was requested during this render
+                            const needsAnotherRender = currentState.pendingRerender;
+                            currentState.isRerendering = false;
+                            currentState.pendingRerender = false;
+
+                            // Diff subscriptions (reuse stable ones)
+                            yield* diffSubscriptions(
+                              key,
+                              currentState,
+                              currentState.renderPhase.accessed,
+                              scheduleItemRerender,
+                            );
+
+                            // If a signal changed during re-render, schedule another
+                            if (needsAnotherRender) {
+                              yield* scheduleItemRerender();
+                            }
+                          }).pipe(
+                            Effect.catchCause((cause) =>
+                              Effect.gen(function* () {
+                                // Cleanup new render result, ensuring markers are removed
+                                // even if cleanup fails (prevents DOM leaks)
+                                yield* Effect.ensuring(
+                                  newResult !== null ? newResult.cleanup : Effect.void,
+                                  Effect.sync(() => {
+                                    if (newStartMarker !== null) newStartMarker.remove();
+                                    if (newEndMarker !== null) newEndMarker.remove();
+                                  }),
+                                );
+                                // Reset flags on error to allow retry
+                                currentState.isRerendering = false;
+                                currentState.pendingRerender = false;
+                                yield* Debug.log({
+                                  event: "render.keyedlist.item.rerender.error",
+                                  key,
+                                  reason: String(cause),
+                                });
+                              }),
+                            ),
+                          );
+                        }),
+                      ),
+                      runtime,
+                      context,
+                    );
+                  });
+
+                const state: ItemState = {
+                  renderPhase,
+                  result,
+                  startMarker,
+                  endMarker,
+                  item,
+                  currentIndex: i,
+                  isRerendering: false,
+                  pendingRerender: false,
+                  subscriptions: new Map(),
+                  scheduleRerender: scheduleItemRerender,
+                };
+
+                // Initial subscription setup
+                yield* diffSubscriptions(key, state, renderPhase.accessed, scheduleItemRerender);
+
+                itemStates.set(key, state);
+                newItemStates.push({
+                  key,
+                  state,
+                  isNew: true,
+                  needsMove: false,
+                  needsRerender: false,
+                });
                 yield* Debug.log({
-                  event: "render.keyedlist.item.remove",
+                  event: "render.keyedlist.item.add",
                   key,
                 });
               }
             }
-          }
 
-          // Compute old indices for existing items in new order
-          // -1 means new item (not in old list)
-          const oldIndicesInNewOrder: Array<number> = [];
-          for (const key of newKeys) {
-            if (key === undefined) continue;
-            const oldIndex = oldKeyToIndex.get(key);
-            oldIndicesInNewOrder.push(oldIndex ?? -1);
-          }
+            // Reorder DOM nodes using minimal moves (LIS optimization)
+            // Process from end to start, keeping track of next sibling reference
+            // Nodes in LIS stay in place; only move nodes not in LIS
+            // Move the full range [startMarker..node] so content stays with its anchor
+            let moveCount = 0;
+            let nextSibling: Node = anchor;
+            const rerenderStates: Array<ItemState> = [];
 
-          // Filter to only existing items (non-negative indices) for LIS
-          const existingIndices = oldIndicesInNewOrder.filter((i) => i >= 0);
-          const lisIndices = new Set(computeLIS(existingIndices));
+            // Iterate in reverse to build correct order
+            for (let i = newItemStates.length - 1; i >= 0; i--) {
+              const currentParent = anchor.parentNode;
+              if (isUnmounted || currentParent === null) {
+                return;
+              }
 
-          // Track which existing items (by their old index) are in LIS
-          const stableOldIndices = new Set<number>();
-          let lisIdx = 0;
-          for (const oldIdx of existingIndices) {
-            if (lisIndices.has(lisIdx)) {
-              stableOldIndices.add(oldIdx);
-            }
-            lisIdx++;
-          }
+              const entry = newItemStates[i];
+              if (entry === undefined) continue;
+              const { state, isNew, needsMove, needsRerender } = entry;
 
-          // Render new items and collect all states in new order
-          const stagedParent = document.createDocumentFragment();
-          const newItemStates: Array<{
-            key: string | number;
-            state: ItemState;
-            isNew: boolean;
-            needsMove: boolean;
-            needsRerender: boolean;
-          }> = [];
+              // Update currentIndex so re-renders use correct index
+              state.currentIndex = i;
 
-          for (let i = 0; i < items.length; i++) {
-            const item = items[i];
-            const key = newKeys[i];
+              if (isNew || needsMove) {
+                if (state.startMarker.parentNode === null || state.endMarker.parentNode === null) {
+                  continue;
+                }
 
-            if (key === undefined) continue;
+                if (
+                  !isNew &&
+                  (state.startMarker.parentNode !== currentParent ||
+                    state.endMarker.parentNode !== currentParent)
+                ) {
+                  continue;
+                }
 
-            const existingState = itemStates.get(key);
-            const oldIndex = oldKeyToIndex.get(key);
-
-            if (existingState !== undefined && oldIndex !== undefined) {
-              // Item exists - update stored item reference
-              // If item identity changed, schedule rerender later.
-              const needsRerender = !Object.is(existingState.item, item);
-              existingState.item = item;
-              // Check if this item needs to move (not in LIS)
-              const needsMove = !stableOldIndices.has(oldIndex);
-              newItemStates.push({
-                key,
-                state: existingState,
-                isNew: false,
-                needsMove,
-                needsRerender,
-              });
-            } else {
-              // New item - create new state
-              const { renderPhase, result, startMarker, endMarker } = yield* renderItem(
-                item,
-                i,
-                null,
-                stagedParent,
-              );
-
-              // Set up subscriptions for this item's accessed signals.
-              // scheduleItemRerender returns lightweight Effect.sync to avoid blocking
-              // signal notification chain. Actual re-render forks via Runtime.runFork.
-              // Batching via isRerendering/pendingRerender coalesces rapid updates.
-              const scheduleItemRerender = (): Effect.Effect<void> =>
-                Effect.sync(() => {
-                  if (isUnmounted) return;
-                  const currentState = itemStates.get(key);
-                  if (currentState === undefined) return;
-
-                  // Coalesce rapid signal changes - mark pending if already rerendering
-                  if (currentState.isRerendering) {
-                    currentState.pendingRerender = true;
+                if (nextSibling.parentNode !== currentParent) {
+                  nextSibling = anchor;
+                  if (nextSibling.parentNode !== currentParent) {
                     return;
                   }
-                  currentState.isRerendering = true;
-
-                  deps.runForkInRenderContext(
-                    Effect.scoped(
-                      Effect.gen(function* () {
-                        // Re-render with same phase (preserves signals).
-                        // renderItem appends [startMarker, content, endMarker] to listParent.
-                        // We then move the new nodes before the old startMarker and
-                        // clean up the old range to preserve DOM order.
-                        const oldStartMarker = currentState.startMarker;
-                        const oldEndMarker = currentState.endMarker;
-
-                        // Track new nodes for cleanup on error
-                        let newResult: RenderResult | null = null;
-                        let newStartMarker: Comment | null = null;
-                        let newEndMarker: Comment | null = null;
-
-                        yield* Effect.gen(function* () {
-                          const rendered = yield* renderItem(
-                            currentState.item,
-                            currentState.currentIndex,
-                            currentState.renderPhase,
-                          );
-                          newResult = rendered.result;
-                          newStartMarker = rendered.startMarker;
-                          newEndMarker = rendered.endMarker;
-
-                          // Move new range [newStartMarker..newEndMarker] before old start
-                          moveRange(newStartMarker, newEndMarker, oldStartMarker);
-
-                          // Clean up old render (removes old content)
-                          yield* currentState.result.cleanup;
-                          oldStartMarker.remove();
-                          oldEndMarker.remove();
-
-                          // Update state
-                          currentState.result = newResult;
-                          currentState.startMarker = newStartMarker;
-                          currentState.endMarker = newEndMarker;
-
-                          // Check if another re-render was requested during this render
-                          const needsAnotherRender = currentState.pendingRerender;
-                          currentState.isRerendering = false;
-                          currentState.pendingRerender = false;
-
-                          // Diff subscriptions (reuse stable ones)
-                          yield* diffSubscriptions(
-                            key,
-                            currentState,
-                            currentState.renderPhase.accessed,
-                            scheduleItemRerender,
-                          );
-
-                          // If a signal changed during re-render, schedule another
-                          if (needsAnotherRender) {
-                            yield* scheduleItemRerender();
-                          }
-                        }).pipe(
-                          Effect.catchCause((cause) =>
-                            Effect.gen(function* () {
-                              // Cleanup new render result, ensuring markers are removed
-                              // even if cleanup fails (prevents DOM leaks)
-                              yield* Effect.ensuring(
-                                newResult !== null ? newResult.cleanup : Effect.void,
-                                Effect.sync(() => {
-                                  if (newStartMarker !== null) newStartMarker.remove();
-                                  if (newEndMarker !== null) newEndMarker.remove();
-                                }),
-                              );
-                              // Reset flags on error to allow retry
-                              currentState.isRerendering = false;
-                              currentState.pendingRerender = false;
-                              yield* Debug.log({
-                                event: "render.keyedlist.item.rerender.error",
-                                key,
-                                reason: String(cause),
-                              });
-                            }),
-                          ),
-                        );
-                      }),
-                    ),
-                    runtime,
-                    context,
-                  );
-                });
-
-              const state: ItemState = {
-                renderPhase,
-                result,
-                startMarker,
-                endMarker,
-                item,
-                currentIndex: i,
-                isRerendering: false,
-                pendingRerender: false,
-                subscriptions: new Map(),
-                scheduleRerender: scheduleItemRerender,
-              };
-
-              // Initial subscription setup
-              yield* diffSubscriptions(
-                key,
-                state,
-                renderPhase.accessed,
-                scheduleItemRerender,
-              );
-
-              itemStates.set(key, state);
-              newItemStates.push({
-                key,
-                state,
-                isNew: true,
-                needsMove: false,
-                needsRerender: false,
-              });
-              yield* Debug.log({
-                event: "render.keyedlist.item.add",
-                key,
-              });
-            }
-          }
-
-          // Reorder DOM nodes using minimal moves (LIS optimization)
-          // Process from end to start, keeping track of next sibling reference
-          // Nodes in LIS stay in place; only move nodes not in LIS
-          // Move the full range [startMarker..node] so content stays with its anchor
-          let moveCount = 0;
-          let nextSibling: Node = anchor;
-          const rerenderStates: Array<ItemState> = [];
-
-          // Iterate in reverse to build correct order
-          for (let i = newItemStates.length - 1; i >= 0; i--) {
-            const currentParent = anchor.parentNode;
-            if (isUnmounted || currentParent === null) {
-              return;
-            }
-
-            const entry = newItemStates[i];
-            if (entry === undefined) continue;
-            const { state, isNew, needsMove, needsRerender } = entry;
-
-            // Update currentIndex so re-renders use correct index
-            state.currentIndex = i;
-
-            if (isNew || needsMove) {
-              if (
-                state.startMarker.parentNode === null ||
-                state.endMarker.parentNode === null
-              ) {
-                continue;
-              }
-
-              if (
-                !isNew &&
-                (state.startMarker.parentNode !== currentParent ||
-                  state.endMarker.parentNode !== currentParent)
-              ) {
-                continue;
-              }
-
-              if (nextSibling.parentNode !== currentParent) {
-                nextSibling = anchor;
-                if (nextSibling.parentNode !== currentParent) {
-                  return;
                 }
+
+                // Move the entire item range [startMarker..endMarker] before nextSibling
+                moveRange(state.startMarker, state.endMarker, nextSibling);
+                moveCount++;
               }
+              // Update next sibling reference: use startMarker since it's the
+              // first node of this item's range
+              nextSibling = state.startMarker;
 
-              // Move the entire item range [startMarker..endMarker] before nextSibling
-              moveRange(state.startMarker, state.endMarker, nextSibling);
-              moveCount++;
+              // Re-render items with same key but new value.
+              if (needsRerender && !needsMove) {
+                rerenderStates.push(state);
+              }
             }
-            // Update next sibling reference: use startMarker since it's the
-            // first node of this item's range
-            nextSibling = state.startMarker;
 
-            // Re-render items with same key but new value.
-            if (needsRerender && !needsMove) {
-              rerenderStates.push(state);
+            yield* Debug.log({
+              event: "render.keyedlist.reorder",
+              total_items: newItemStates.length,
+              moves: moveCount,
+              stable_nodes: newItemStates.length - moveCount,
+            });
+
+            yield* Debug.log({
+              event: "render.keyedlist.state",
+              phase: "after-reorder",
+              key_order: [...keyOrder],
+              new_keys: newKeys,
+              move_count: moveCount,
+            });
+
+            // Re-render changed items only when order is stable.
+            // When reorder happened, defer to next source update to avoid
+            // interfering with move sequencing for fragment ranges.
+            if (moveCount === 0) {
+              for (const state of rerenderStates) {
+                yield* state.scheduleRerender();
+              }
             }
-          }
 
-          yield* Debug.log({
-            event: "render.keyedlist.reorder",
-            total_items: newItemStates.length,
-            moves: moveCount,
-            stable_nodes: newItemStates.length - moveCount,
-          });
-
-          yield* Debug.log({
-            event: "render.keyedlist.state",
-            phase: "after-reorder",
-            key_order: [...keyOrder],
-            new_keys: newKeys,
-            move_count: moveCount,
-          });
-
-          // Re-render changed items only when order is stable.
-          // When reorder happened, defer to next source update to avoid
-          // interfering with move sequencing for fragment ranges.
-          if (moveCount === 0) {
-            for (const state of rerenderStates) {
-              yield* state.scheduleRerender();
+            // Update key order
+            keyOrder.length = 0;
+            for (const key of newKeys) {
+              if (key !== undefined) {
+                keyOrder.push(key);
+              }
             }
-          }
 
-          // Update key order
-          keyOrder.length = 0;
-          for (const key of newKeys) {
-            if (key !== undefined) {
-              keyOrder.push(key);
-            }
-          }
-
-          yield* Debug.log({
-            event: "render.keyedlist.state",
-            phase: "committed",
-            key_order: [...keyOrder],
-          });
-        }).pipe(
-          Effect.catchCause((cause) =>
-            Debug.log({
-              event: "render.keyedlist.update.error",
-              reason: String(cause),
+            yield* Debug.log({
+              event: "render.keyedlist.state",
+              phase: "committed",
+              key_order: [...keyOrder],
+            });
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Debug.log({
+                event: "render.keyedlist.update.error",
+                reason: String(cause),
+              }),
+            ),
+          ),
+        ).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              isUpdating = false;
+              if (pendingUpdate && !isUnmounted) {
+                pendingUpdate = false;
+                updateList();
+              }
             }),
           ),
         ),
-      ).pipe(
-        Effect.ensuring(
-          Effect.sync(() => {
-            isUpdating = false;
-            if (pendingUpdate && !isUnmounted) {
-              pendingUpdate = false;
-              updateList();
-            }
-          }),
-        ),
-      ),
-      runtime,
-      context,
-    );
-  }
+        runtime,
+        context,
+      );
+    }
 
-  // Initial render
-  yield* Effect.sync(updateList);
+    // Initial render
+    yield* Effect.sync(updateList);
 
-  // Subscribe to source signal changes
-  // updateList returns void but is wrapped in sync Effect by the listener
-  const unsubscribeSource = yield* Signal.subscribe(source, () => Effect.sync(updateList));
+    // Subscribe to source signal changes
+    // updateList returns void but is wrapped in sync Effect by the listener
+    const unsubscribeSource = yield* Signal.subscribe(source, () => Effect.sync(updateList));
 
-  return {
-    node: anchor,
-    cleanup: Effect.gen(function* () {
-      isUnmounted = true;
-      yield* unsubscribeSource;
+    return {
+      node: anchor,
+      cleanup: Effect.gen(function* () {
+        isUnmounted = true;
+        yield* unsubscribeSource;
 
-      // Clean up all items
-      for (const [, state] of itemStates) {
-        for (const [, unsubscribe] of state.subscriptions) {
-          yield* unsubscribe;
+        // Clean up all items
+        for (const [, state] of itemStates) {
+          for (const [, unsubscribe] of state.subscriptions) {
+            yield* unsubscribe;
+          }
+          yield* state.result.cleanup;
+          state.startMarker.remove();
+          state.endMarker.remove();
         }
-        yield* state.result.cleanup;
-        state.startMarker.remove();
-        state.endMarker.remove();
-      }
-      itemStates.clear();
-      anchor.remove();
-    }),
-  };
-});
+        itemStates.clear();
+        anchor.remove();
+      }),
+    };
+  });

--- a/packages/core/src/primitives/render-portal.ts
+++ b/packages/core/src/primitives/render-portal.ts
@@ -44,7 +44,13 @@ export const renderPortal = (
     const normalizedChildren = yield* Element.fromChildren(children);
     const childResults: Array<RenderResult> = [];
     for (const child of normalizedChildren) {
-      const result = yield* deps.renderElement(child, targetElement, renderContext, context, options);
+      const result = yield* deps.renderElement(
+        child,
+        targetElement,
+        renderContext,
+        context,
+        options,
+      );
       childResults.push(result);
     }
 

--- a/packages/core/src/primitives/render-provide.ts
+++ b/packages/core/src/primitives/render-provide.ts
@@ -27,8 +27,15 @@ export const renderProvide = (
   deps: RenderProvideDeps,
 ): Effect.Effect<RenderResult, unknown, unknown> =>
   Effect.gen(function* () {
-    const mergedContext = context !== null ? Context.merge(context, providedContext) : providedContext;
-    const childResult = yield* deps.renderElement(child, parent, renderContext, mergedContext, options);
+    const mergedContext =
+      context !== null ? Context.merge(context, providedContext) : providedContext;
+    const childResult = yield* deps.renderElement(
+      child,
+      parent,
+      renderContext,
+      mergedContext,
+      options,
+    );
 
     return {
       get node() {

--- a/packages/core/src/primitives/render-signal-element.ts
+++ b/packages/core/src/primitives/render-signal-element.ts
@@ -65,7 +65,10 @@ export const renderSignalElement = (
         const element = renderValue(value);
         const result = yield* deps
           .renderElement(element, parent, renderContext, context, options)
-          .pipe(Scope.provide(scope), Effect.onError(() => Scope.close(scope, Exit.void)));
+          .pipe(
+            Scope.provide(scope),
+            Effect.onError(() => Scope.close(scope, Exit.void)),
+          );
         return { result, scope };
       });
 
@@ -91,7 +94,10 @@ export const renderSignalElement = (
             const element = renderValue(newValue);
             const result = yield* deps
               .renderElement(element, tempFragment, renderContext, context, options)
-              .pipe(Scope.provide(scope), Effect.onError(() => Scope.close(scope, Exit.void)));
+              .pipe(
+                Scope.provide(scope),
+                Effect.onError(() => Scope.close(scope, Exit.void)),
+              );
 
             if (myVersion !== swapVersion) {
               yield* result.cleanup;

--- a/packages/core/src/primitives/renderer.ts
+++ b/packages/core/src/primitives/renderer.ts
@@ -428,7 +428,9 @@ const renderElement = (
     ),
 
     Match.tag("Provide", ({ context: providedContext, child }) =>
-      renderProvide(providedContext, child, parent, renderContext, context, options, { renderElement }),
+      renderProvide(providedContext, child, parent, renderContext, context, options, {
+        renderElement,
+      }),
     ),
 
     Match.tag("Intrinsic", ({ tag, props, children, key }) =>

--- a/packages/core/src/vite/__tests__/plugin.test.ts
+++ b/packages/core/src/vite/__tests__/plugin.test.ts
@@ -1859,7 +1859,9 @@ mountDocument(<App />, { manifest: routes.manifest })
       build: Schema.Struct({
         rollupOptions: Schema.Struct({
           onwarn: Schema.declare(
-            (u: unknown): u is (warning: { readonly message?: string }, handler: () => void) => void =>
+            (
+              u: unknown,
+            ): u is (warning: { readonly message?: string }, handler: () => void) => void =>
               typeof u === "function",
           ),
         }),

--- a/packages/core/src/vite/plugin.ts
+++ b/packages/core/src/vite/plugin.ts
@@ -116,7 +116,8 @@ export const isTryggMixedDynamicImportWarning = (warning: RollupWarning): boolea
   return message.includes("/packages/core/dist/") || message.includes("/node_modules/trygg/dist/");
 };
 
-const makeRollupOnwarn = (userOnwarn: RollupWarningHandler | undefined): RollupWarningHandler =>
+const makeRollupOnwarn =
+  (userOnwarn: RollupWarningHandler | undefined): RollupWarningHandler =>
   (warning, defaultHandler) => {
     if (isTryggMixedDynamicImportWarning(warning)) return;
     if (userOnwarn !== undefined) {
@@ -2249,18 +2250,18 @@ export const makeBuildOutput = ({
           })
         : output !== "server"
           ? Effect.void
-      : Effect.gen(function* () {
-          const paths = { appDir, generatedDir };
-          const serverEntryPath = yield* files
-            .writeProductionServerEntry(paths)
-            .pipe(Effect.provideService(ServerPlatform, serverPlatform));
+          : Effect.gen(function* () {
+              const paths = { appDir, generatedDir };
+              const serverEntryPath = yield* files
+                .writeProductionServerEntry(paths)
+                .pipe(Effect.provideService(ServerPlatform, serverPlatform));
 
-          yield* Effect.logInfo("Building production server...");
-          yield* buildServer(serverEntryPath, config);
-          yield* Effect.logInfo("Server build complete").pipe(
-            Effect.annotateLogs("style", "success"),
-          );
-        }),
+              yield* Effect.logInfo("Building production server...");
+              yield* buildServer(serverEntryPath, config);
+              yield* Effect.logInfo("Server build complete").pipe(
+                Effect.annotateLogs("style", "success"),
+              );
+            }),
 });
 
 const viteServerBuild = (


### PR DESCRIPTION
## Summary
- Apply `bun check` formatter output on current `main` after the SVG canary merge.
- Keep the canary publish path green without replaying the already-merged SVG branch stack.

## Verification
- `bun check`