### PR TITLE
feat(core): lifecycle-owned component provision

### DIFF
--- a/packages/core/src/debug/debug.ts
+++ b/packages/core/src/debug/debug.ts
@@ -159,6 +159,19 @@ type RenderComponentRerenderErrorEvent = BaseEvent & {
   readonly reason: string;
 };
 
+type ProviderAcquireEvent = BaseEvent & {
+  readonly event: "provider.acquire";
+  readonly component?: string | undefined;
+  readonly reason: "mount" | "rerender" | "identity-change" | "key-change" | "unmount" | "failure";
+};
+
+type ProviderFailureEvent = BaseEvent & {
+  readonly event: "provider.failure";
+  readonly component?: string | undefined;
+  readonly reason: "failure";
+  readonly cause: string;
+};
+
 type RenderSignalTextInitialEvent = BaseEvent & {
   readonly event: "render.signaltext.initial";
   readonly signal_id: string;
@@ -822,6 +835,8 @@ export type DebugEvent =
   | RenderComponentCleanupEvent
   | RenderComponentErrorEvent
   | RenderComponentRerenderErrorEvent
+  | ProviderAcquireEvent
+  | ProviderFailureEvent
   | RenderSignalTextInitialEvent
   | RenderSignalTextUpdateEvent
   | RenderSignalElementInitialEvent

--- a/packages/core/src/internal/unsafe.ts
+++ b/packages/core/src/internal/unsafe.ts
@@ -8,7 +8,7 @@
  * - Runtime-effectful operations use Debug.log for observability
  * - This is the ONLY file where `as` casts are permitted
  */
-import { Effect, Layer, Context } from "effect";
+import { Effect, Layer, Context, Scope } from "effect";
 import * as Match from "effect/Match";
 import * as Debug from "../debug/debug.js";
 import type { Component } from "../primitives/component.js";
@@ -69,6 +69,26 @@ export const unsafeBuildContext = <A>(
     const merged = yield* unsafeMergeLayers(layers);
     return yield* Effect.scoped(Layer.build(merged as Parameters<typeof Layer.build>[0]));
   }) as Effect.Effect<Context.Context<A>, never, never>;
+
+/**
+ * Build one provider layer into an explicit lifecycle scope.
+ *
+ * SAFETY: Provider layers are stored as Layer.Any at the element boundary after
+ * public Component.provide typing has validated the layer. The returned Context
+ * is widened because renderer context propagation is intentionally untyped.
+ */
+export const unsafeBuildProviderContext = (
+  layer: Layer.Layer<never, unknown, unknown>,
+  scope: Scope.Scope,
+  parentContext: Context.Context<unknown> | null,
+): Effect.Effect<Context.Context<unknown>, unknown, unknown> => {
+  const build = Layer.buildWithScope(layer, scope) as Effect.Effect<
+    Context.Context<unknown>,
+    unknown,
+    unknown
+  >;
+  return parentContext === null ? build : Effect.provide(build, parentContext);
+};
 
 // =============================================================================
 // Component Tagging

--- a/packages/core/src/primitives/__tests__/component.test.tsx
+++ b/packages/core/src/primitives/__tests__/component.test.tsx
@@ -17,13 +17,14 @@
  * - Verify provide propagates to children
  */
 import { assert, describe, it } from "@effect/vitest";
-import { Data, Effect, Layer, Result, Context } from "effect";
+import { Data, Effect, Exit, Layer, Result, Context, Scope } from "effect";
 
 // Tagged error for testing component failures
 class ComponentError extends Data.TaggedError("ComponentError")<{ message: string }> {}
 import * as Component from "../component.js";
 import { unsafeBuildContext } from "../../internal/unsafe.js";
-import { render } from "../../testing/index.js";
+import { click, render } from "../../testing/index.js";
+import * as Signal from "../signal.js";
 
 // Test service for DI tests
 class TestService extends Context.Service<TestService, { value: string }>()("TestService") {}
@@ -86,7 +87,7 @@ describe("Component.gen without props", () => {
       const MyComponent = Component.gen(function* () {
         const service = yield* TestService;
         return <div data-testid="service">{service.value}</div>;
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<MyComponent />);
 
@@ -154,7 +155,7 @@ describe("Component.gen with props", () => {
             {prefix}-{service.value}
           </div>
         );
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<MyComponent prefix="Test" />);
 
@@ -198,7 +199,7 @@ describe("Component.provide", () => {
       const MyComponent = Component.gen(function* () {
         const service = yield* TestService;
         return <div data-testid="provided">{service.value}</div>;
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<MyComponent />);
 
@@ -219,7 +220,7 @@ describe("Component.provide", () => {
             <Child />
           </div>
         );
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<Parent />);
 
@@ -231,7 +232,7 @@ describe("Component.provide", () => {
     Effect.gen(function* () {
       const MyComponent = Component.gen(function* () {
         return <div data-testid="wrapped">Content</div>;
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<MyComponent />);
 
@@ -253,11 +254,11 @@ describe("Component.provide", () => {
 
       const Parent = Component.gen(function* () {
         return <Child />;
-      }).provide(Layer.succeed(AnotherService, { other: "other-value" }));
+      }).pipe(Component.provide(Layer.succeed(AnotherService, { other: "other-value" })));
 
       const GrandParent = Component.gen(function* () {
         return <Parent />;
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<GrandParent />);
 
@@ -274,14 +275,93 @@ describe("Component.provide", () => {
         const a = yield* ServiceA;
         const b = yield* ServiceB;
         return <div data-testid="chained">{`${a.a}-${b.b}`}</div>;
-      })
-        .provide(Layer.succeed(ServiceA, { a: "A" }))
-        .provide(Layer.succeed(ServiceB, { b: "B" }));
+      }).pipe(
+        Component.provide(Layer.succeed(ServiceA, { a: "A" })),
+        Component.provide(Layer.succeed(ServiceB, { b: "B" })),
+      );
 
       const { getByTestId } = yield* render(<MyComponent />);
 
       assert.strictEqual((yield* getByTestId("chained")).textContent, "A-B");
     }),
+  );
+
+  it.effect(
+    "should acquire pipeable lifecycle provider once while rerendering stable component",
+    () =>
+      Effect.gen(function* () {
+        let acquireCount = 0;
+        let finalizeCount = 0;
+
+        class Store extends Context.Service<
+          Store,
+          {
+            readonly count: Signal.Signal<number>;
+            readonly increment: Effect.Effect<void>;
+          }
+        >()("Store") {}
+
+        const StoreLive = Layer.effect(
+          Store,
+          Effect.gen(function* () {
+            acquireCount += 1;
+            const count = yield* Signal.make(0);
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => {
+                finalizeCount += 1;
+              }),
+            );
+            return {
+              count,
+              increment: Signal.update(count, (value) => value + 1),
+            };
+          }),
+        );
+
+        const StoreView = Component.gen(function* () {
+          const store = yield* Store;
+          const count = yield* Signal.get(store.count);
+          return (
+            <button data-testid="store" onClick={() => store.increment}>
+              {String(count)}
+            </button>
+          );
+        });
+
+        const App = Component.gen(function* () {
+          const parentRenders = yield* Signal.make(0);
+          const renderCount = yield* Signal.get(parentRenders);
+          return (
+            <section>
+              <button
+                data-testid="rerender"
+                onClick={() => Signal.update(parentRenders, (value) => value + 1)}
+              >
+                {String(renderCount)}
+              </button>
+              <StoreView />
+            </section>
+          );
+        }).pipe(Component.provide(StoreLive));
+
+        const scope = yield* Scope.make();
+        const result = yield* render(<App />).pipe(Scope.provide(scope));
+
+        assert.strictEqual(acquireCount, 1);
+        assert.strictEqual((yield* result.getByTestId("store")).textContent, "0");
+
+        yield* click(yield* result.getByTestId("store"));
+        yield* Effect.yieldNow;
+        assert.strictEqual((yield* result.getByTestId("store")).textContent, "1");
+
+        yield* click(yield* result.getByTestId("rerender"));
+        yield* Effect.yieldNow;
+        assert.strictEqual(acquireCount, 1);
+        assert.strictEqual((yield* result.getByTestId("store")).textContent, "1");
+
+        yield* Scope.close(scope, Exit.void);
+        assert.strictEqual(finalizeCount, 1);
+      }),
   );
 });
 
@@ -296,7 +376,7 @@ describe("Service access", () => {
       const MyComponent = Component.gen(function* () {
         const service = yield* TestService;
         return <div data-testid="service">{service.value}</div>;
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<MyComponent />);
 
@@ -394,7 +474,7 @@ describe("isEffectComponent", () => {
   it("should return true for components with .provide() applied", () => {
     const MyComponent = Component.gen(function* () {
       return <div>Test</div>;
-    }).provide(testServiceLayer);
+    }).pipe(Component.provide(testServiceLayer));
 
     assert.isTrue(Component.isEffectComponent(MyComponent));
   });
@@ -459,7 +539,7 @@ describe("Component function API", () => {
           const service = yield* TestService;
           return <div data-testid="svc">{service.value}</div>;
         }),
-      ).provide(testServiceLayer);
+      ).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<MyComponent />);
 
@@ -471,10 +551,10 @@ describe("Component function API", () => {
 // =============================================================================
 // Layer Precedence
 // =============================================================================
-// Scope: Verify last-write-wins semantics
+// Scope: Verify nested provider semantics
 
 describe("Layer Precedence", () => {
-  it.effect("should override via chaining (last provision wins)", () =>
+  it.effect("should preserve Effect nesting via chaining (inner provision wins)", () =>
     Effect.gen(function* () {
       class Theme extends Context.Service<Theme, { color: string }>()("Theme") {}
 
@@ -484,35 +564,30 @@ describe("Layer Precedence", () => {
       const MyComponent = Component.gen(function* () {
         const theme = yield* Theme;
         return <div data-testid="theme">{theme.color}</div>;
-      })
-        .provide(BlueTheme)
-        .provide(RedTheme);
+      }).pipe(Component.provide(BlueTheme), Component.provide(RedTheme));
 
       const { getByTestId } = yield* render(<MyComponent />);
 
-      assert.strictEqual((yield* getByTestId("theme")).textContent, "red");
+      assert.strictEqual((yield* getByTestId("theme")).textContent, "blue");
     }),
   );
 
-  it.effect("should override via array order (last in array wins)", () =>
-    Effect.gen(function* () {
-      class Theme extends Context.Service<Theme, { color: string }>()("Theme") {}
+  it("rejects legacy array provision", () => {
+    class Theme extends Context.Service<Theme, { color: string }>()("Theme") {}
 
-      const BlueTheme = Layer.succeed(Theme, { color: "blue" });
-      const RedTheme = Layer.succeed(Theme, { color: "red" });
+    const BlueTheme = Layer.succeed(Theme, { color: "blue" });
+    const RedTheme = Layer.succeed(Theme, { color: "red" });
 
-      const MyComponent = Component.gen(function* () {
-        const theme = yield* Theme;
-        return <div data-testid="theme">{theme.color}</div>;
-      }).provide([BlueTheme, RedTheme]);
+    const MyComponent = Component.gen(function* () {
+      const theme = yield* Theme;
+      return <div data-testid="theme">{theme.color}</div>;
+    });
 
-      const { getByTestId } = yield* render(<MyComponent />);
+    // @ts-expect-error array provision was removed; use one Component.provide(layer) per call.
+    MyComponent.pipe(Component.provide([BlueTheme, RedTheme]));
+  });
 
-      assert.strictEqual((yield* getByTestId("theme")).textContent, "red");
-    }),
-  );
-
-  it.effect("should allow override after full provision", () =>
+  it.effect("should keep fully provided component services nested inside later provision", () =>
     Effect.gen(function* () {
       class Theme extends Context.Service<Theme, { color: string }>()("Theme") {}
 
@@ -522,13 +597,13 @@ describe("Layer Precedence", () => {
       const BaseComponent = Component.gen(function* () {
         const theme = yield* Theme;
         return <div data-testid="theme">{theme.color}</div>;
-      }).provide(BlueTheme);
+      }).pipe(Component.provide(BlueTheme));
 
-      const OverriddenComponent = BaseComponent.provide(RedTheme);
+      const OverriddenComponent = BaseComponent.pipe(Component.provide(RedTheme));
 
       const { getByTestId } = yield* render(<OverriddenComponent />);
 
-      assert.strictEqual((yield* getByTestId("theme")).textContent, "red");
+      assert.strictEqual((yield* getByTestId("theme")).textContent, "blue");
     }),
   );
 });
@@ -544,7 +619,7 @@ describe("Immutability", () => {
       return <div>Base</div>;
     });
 
-    const ProvidedComponent = BaseComponent.provide(testServiceLayer);
+    const ProvidedComponent = BaseComponent.pipe(Component.provide(testServiceLayer));
 
     // Original should still have empty layers
     assert.strictEqual(BaseComponent._layers.length, 0);
@@ -567,9 +642,9 @@ describe("Immutability", () => {
         );
       });
 
-      // Provide ServiceA via .provide; ServiceB via outer layer
-      const VariantA = BaseComponent.provide(Layer.succeed(ServiceA, { value: "A" })).provide(
-        Layer.succeed(ServiceB, { value: "B" }),
+      const VariantA = BaseComponent.pipe(
+        Component.provide(Layer.succeed(ServiceA, { value: "A" })),
+        Component.provide(Layer.succeed(ServiceB, { value: "B" })),
       );
 
       const { getByTestId: getA } = yield* render(<VariantA />);
@@ -593,7 +668,9 @@ describe("Immutability", () => {
       });
 
       // Only provide ServiceA — ServiceB is missing
-      const VariantA = BaseComponent.provide(Layer.succeed(ServiceA, { value: "A" }));
+      const VariantA = BaseComponent.pipe(
+        Component.provide(Layer.succeed(ServiceA, { value: "A" })),
+      );
 
       const context = yield* unsafeBuildContext<unknown>([]);
       const result = yield* render(<VariantA />).pipe(
@@ -608,10 +685,10 @@ describe("Immutability", () => {
   it("should create distinct objects on chaining", () => {
     const Step1 = Component.gen(function* () {
       return <div>Step1</div>;
-    }).provide(testServiceLayer);
+    }).pipe(Component.provide(testServiceLayer));
 
-    const Step2 = Step1.provide(testServiceLayer);
-    const Step3 = Step2.provide(testServiceLayer);
+    const Step2 = Step1.pipe(Component.provide(testServiceLayer));
+    const Step3 = Step2.pipe(Component.provide(testServiceLayer));
 
     // Each step should be a different object
     assert.notStrictEqual(Step1, Step2);
@@ -632,7 +709,7 @@ describe("Edge Cases", () => {
         return <div data-testid="no-req">No requirements</div>;
       });
 
-      const ProvidedComponent = MyComponent.provide(testServiceLayer);
+      const ProvidedComponent = MyComponent.pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<ProvidedComponent />);
 
@@ -647,7 +724,7 @@ describe("Edge Cases", () => {
       ) {
         const { title } = yield* Props;
         return <div data-testid="props">{title}</div>;
-      }).provide(testServiceLayer);
+      }).pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<MyComponent title="Test Title" />);
 
@@ -663,7 +740,7 @@ describe("Edge Cases", () => {
       });
 
       // Providing extra layers should be harmless
-      const ProvidedComponent = MyComponent.provide(testServiceLayer);
+      const ProvidedComponent = MyComponent.pipe(Component.provide(testServiceLayer));
 
       const { getByTestId } = yield* render(<ProvidedComponent />);
 

--- a/packages/core/src/primitives/__tests__/error-boundary.test.tsx
+++ b/packages/core/src/primitives/__tests__/error-boundary.test.tsx
@@ -54,8 +54,8 @@ describe("ErrorBoundary .provide() preservation", () => {
         ErrorBoundary.catchAll(catchAllView("fallback")),
       );
 
-      // Apply .provide() - this should NOT break the error boundary
-      const ProvidedComponent = SafeComponent.provide(TestLayer);
+      // Apply Component.provide() - this should NOT break the error boundary
+      const ProvidedComponent = SafeComponent.pipe(Component.provide(TestLayer));
       const element = ProvidedComponent({});
 
       // Render and assert fallback shown, not crash
@@ -80,7 +80,7 @@ describe("ErrorBoundary .provide() preservation", () => {
         ErrorBoundary.catchAll(catchAllView("error")),
       );
 
-      const ProvidedComponent = SafeComponent.provide(TestLayer);
+      const ProvidedComponent = SafeComponent.pipe(Component.provide(TestLayer));
       const element = ProvidedComponent({});
 
       const { getByTestId } = yield* render(element);
@@ -139,7 +139,7 @@ describe("ErrorBoundary handler requirements propagation", () => {
       );
 
       // Render with ErrorTheme provided - should work
-      const ProvidedComponent = SafeComponent.provide(ErrorThemeLayer);
+      const ProvidedComponent = SafeComponent.pipe(Component.provide(ErrorThemeLayer));
       const element = ProvidedComponent({});
 
       const { getByText } = yield* render(element);

--- a/packages/core/src/primitives/__tests__/provide-context.test.tsx
+++ b/packages/core/src/primitives/__tests__/provide-context.test.tsx
@@ -137,11 +137,11 @@ describe("Provide context merging", () => {
 
       const Outer = Component.gen(function* () {
         return <Inner />;
-      }).provide(Layer.succeed(ThemeService, { color: "blue" }));
+      }).pipe(Component.provide(Layer.succeed(ThemeService, { color: "blue" })));
 
       const App = Component.gen(function* () {
         return <Outer />;
-      }).provide(Layer.succeed(AuthService, { user: "alice" }));
+      }).pipe(Component.provide(Layer.succeed(AuthService, { user: "alice" })));
 
       const { getByTestId } = yield* render(<App />);
       const btn = yield* getByTestId("btn");

--- a/packages/core/src/primitives/__tests__/render-provide.test.tsx
+++ b/packages/core/src/primitives/__tests__/render-provide.test.tsx
@@ -16,7 +16,7 @@ describe("render-provide", () => {
 
       const Parent = Component.gen(function* () {
         return <Child />;
-      }).provide(Layer.succeed(Label, { value: "provided" }));
+      }).pipe(Component.provide(Layer.succeed(Label, { value: "provided" })));
 
       const { getByTestId } = yield* render(<Parent />);
 

--- a/packages/core/src/primitives/__tests__/renderer.test.tsx
+++ b/packages/core/src/primitives/__tests__/renderer.test.tsx
@@ -357,7 +357,7 @@ describe("SignalElement rendering", () => {
 
       const App = Component.gen(function* () {
         return <div data-testid="context-swap">{viewSignal}</div>;
-      }).provide(themeLayer);
+      }).pipe(Component.provide(themeLayer));
 
       const { getByTestId, queryByTestId } = yield* render(<App />);
 
@@ -2448,7 +2448,7 @@ describe("Provide element", () => {
 
       const Parent = Component.gen(function* () {
         return <Child />;
-      }).provide(Layer.succeed(TestCtx, { value: "provided" }));
+      }).pipe(Component.provide(Layer.succeed(TestCtx, { value: "provided" })));
 
       const { getByTestId } = yield* render(<Parent />);
 
@@ -2475,7 +2475,7 @@ describe("Provide element", () => {
 
       const TopLevel = Component.gen(function* () {
         return <MiddleChild />;
-      }).provide(Layer.succeed(DeepCtx, { nested: "deep-value" }));
+      }).pipe(Component.provide(Layer.succeed(DeepCtx, { nested: "deep-value" })));
 
       const { getByTestId } = yield* render(<TopLevel />);
 

--- a/packages/core/src/primitives/__tests__/signal.test.ts
+++ b/packages/core/src/primitives/__tests__/signal.test.ts
@@ -1148,7 +1148,9 @@ describe("Signal.suspend", () => {
         Signal.exhaustive,
       );
 
-      const Provided = suspended.provide(Layer.succeed(PendingTheme, { label: "loading" }));
+      const Provided = suspended.pipe(
+        Component.provide(Layer.succeed(PendingTheme, { label: "loading" })),
+      );
       const result = yield* Effect.exit(render(Provided({})));
       assert.isTrue(Exit.isSuccess(result));
     }),

--- a/packages/core/src/primitives/component.ts
+++ b/packages/core/src/primitives/component.ts
@@ -10,10 +10,10 @@
  * @since 1.0.0
  * @module trygg/primitives/component
  */
-import { Data, Effect, Layer } from "effect";
+import { Data, Effect, Layer, Pipeable } from "effect";
 import * as Context from "effect/Context";
-import { unsafeBuildContext, unsafeTagCallable } from "../internal/unsafe.js";
-import { Element, provideElement, type ComponentElementWithRequirements } from "./element.js";
+import { unsafeTagCallable } from "../internal/unsafe.js";
+import { Element, type ComponentElementWithRequirements } from "./element.js";
 
 /**
  * Error raised when an invalid component type is used in JSX.
@@ -91,74 +91,25 @@ type LegacyGenResume = undefined;
 
 const effectComponentTag = "EffectComponent" as const;
 
-// buildContextFromLayers moved to internal/unsafe.ts as unsafeBuildContext
-// Handles heterogeneous Layer.Any[] merging at a type system boundary
-
 /**
- * Deduplicate layers by keeping only the last occurrence of each service
- * This prevents unnecessary layer accumulation while preserving last-write-wins semantics
- * @internal
- */
-const deduplicateLayers = (layers: ReadonlyArray<Layer.Any>): ReadonlyArray<Layer.Any> => {
-  // For now, we keep all layers and let Layer.mergeAll handle precedence
-  // In a more sophisticated implementation, we could track service tags and deduplicate
-  // But Layer.mergeAll already handles "last layer wins" correctly
-  return layers;
-};
-
-/**
- * Tag a component function with Component metadata
+ * Tag a component function with Component metadata.
  * @internal
  */
 export const tagComponent = <Props, RuntimeProps, E, R>(
   fn: (props: RuntimeProps) => Element,
-  layers: ReadonlyArray<Layer.Any> = [],
+  layers: ReadonlyArray<unknown> = [],
   runFn?: (props: RuntimeProps) => Effect.Effect<Element, E, unknown>,
   displayName?: string,
-): Component.Type<Props, E, R> => {
-  // Build provide as a standalone function, then pass to unsafeTagCallable
-  // The provide implementation serves multiple overloads — the overload
-  // signatures on Component.Type ensure type safety at call sites
-  const provide = (layerOrLayers: Layer.Any | ReadonlyArray<Layer.Any>) => {
-    const newLayers = Array.isArray(layerOrLayers) ? layerOrLayers : [layerOrLayers];
-    // Append new layers - Layer.mergeAll applies left-to-right with last-write-wins
-    // When we call .provide(A).provide(B), mergedLayers = [A, B], B wins
-    // When we call .provide([A, B]), mergedLayers = [A, B], B wins (last in array)
-    const mergedLayers = deduplicateLayers([...layers, ...newLayers]);
-
-    // Create new component function that preserves the Props type
-    const newComponent = (props: RuntimeProps): Element => {
-      // Create a Component element whose run function builds context and wraps output in Provide
-      const run = (): Effect.Effect<Element, E, unknown> =>
-        Effect.gen(function* () {
-          // Build context from layers
-          // Layer.mergeAll applies layers left-to-right with last-write-wins semantics
-          // mergedLayers is ordered chronologically, so last layer wins correctly
-          const context = yield* unsafeBuildContext(mergedLayers);
-
-          // Execute the stored runFn directly to get the element
-          // Provide the context to satisfy service requirements
-          const element = runFn ? yield* runFn(props).pipe(Effect.provide(context)) : fn(props);
-
-          // Wrap the element in a Provide element so context propagates to children
-          return provideElement(context, element);
-        });
-
-      return Element.fromEffect(Effect.suspend(run), { identity: newComponent, inputs: props });
-    };
-
-    // Tag the new component with merged layers and preserve the runFn and displayName
-    return tagComponent<Props, RuntimeProps, E, R>(newComponent, mergedLayers, runFn, displayName);
-  };
-
-  return unsafeTagCallable<Component.Type<Props, E, R>>(fn, {
+): Component.Type<Props, E, R> =>
+  unsafeTagCallable<Component.Type<Props, E, R>>(fn, {
     _tag: effectComponentTag,
     _layers: layers,
     _runFn: runFn,
     _displayName: displayName,
-    provide,
+    pipe() {
+      return Pipeable.pipeArguments(this, arguments);
+    },
   });
-};
 
 const normalizeResult = <E, R>(
   effect: Effect.Effect<ComponentResult, E, R>,
@@ -203,7 +154,7 @@ function makeComponent<P extends object = {}>(): <E, R>(
  */
 export interface ComponentInternal {
   readonly _tag: "EffectComponent";
-  readonly _layers: ReadonlyArray<Layer.Any>;
+  readonly _layers: ReadonlyArray<unknown>;
   readonly _baseFn: (props: unknown) => Element;
 }
 
@@ -215,45 +166,13 @@ export interface ComponentInternal {
 export declare namespace Component {
   export interface Type<Props = never, _E = never, _R = never> {
     readonly _tag: "EffectComponent";
-    readonly _layers: ReadonlyArray<Layer.Any>;
+    readonly _layers: ReadonlyArray<unknown>;
     readonly _runFn?: (
       props: ComponentCallProps<Props>,
     ) => Effect.Effect<Element, unknown, unknown>;
     readonly _displayName?: string;
+    readonly pipe: Pipeable.Pipeable["pipe"];
     (props: ComponentCallProps<Props>): ComponentElementWithRequirements<_R>;
-
-    /**
-     * Provide services to satisfy component requirements at definition time.
-     * Returns a new component with narrowed R type.
-     *
-     * @example
-     * ```tsx
-     * const Button = Component.gen(function* () {
-     *   const theme = yield* Theme;
-     *   return <button style={theme.primary}>Click</button>;
-     * }).provide(themeLayer);
-     * ```
-     */
-    provide<ROut, E2, RIn>(
-      layer: Layer.Layer<ROut, E2, RIn>,
-    ): Component.Type<Props, _E | E2, RIn | Exclude<_R, ROut>>;
-
-    /**
-     * Provide multiple services at once using an array of layers.
-     *
-     * @example
-     * ```tsx
-     * const Button = Component.gen(...).provide([themeLayer, analyticsLayer]);
-     * ```
-     */
-    provide<const Layers extends readonly [Layer.Any, ...Array<Layer.Any>]>(
-      layers: Layers,
-    ): Component.Type<
-      Props,
-      _E | { [k in keyof Layers]: Layer.Error<Layers[k]> }[number],
-      | { [k in keyof Layers]: Layer.Services<Layers[k]> }[number]
-      | Exclude<_R, { [k in keyof Layers]: Layer.Success<Layers[k]> }[number]>
-    >;
   }
 }
 
@@ -460,8 +379,29 @@ export const gen: Gen = function <P extends object>(f?: unknown): any {
   });
 };
 
+export const provide =
+  <ROut, E2, RIn>(layer: Layer.Layer<ROut, E2, RIn>) =>
+  <Props, E, R>(
+    component: Component.Type<Props, E, R>,
+  ): Component.Type<Props, E | E2, RIn | Exclude<R, ROut>> => {
+    const providedComponent = (props: ComponentCallProps<Props>): Element =>
+      Element.fromEffect(Effect.succeed(component(props)), {
+        identity: providedComponent,
+        inputs: props,
+        provider: { layer, displayName: component._displayName },
+      });
+
+    return tagComponent<Props, ComponentCallProps<Props>, E | E2, RIn | Exclude<R, ROut>>(
+      providedComponent,
+      [layer],
+      (props) => Effect.succeed(component(props)),
+      component._displayName,
+    );
+  };
+
 type ComponentApi = typeof makeComponent & {
   readonly gen: typeof gen;
+  readonly provide: typeof provide;
 };
 
 /**
@@ -485,4 +425,5 @@ type ComponentApi = typeof makeComponent & {
  */
 export const Component: ComponentApi = Object.assign(makeComponent, {
   gen,
+  provide,
 });

--- a/packages/core/src/primitives/element.ts
+++ b/packages/core/src/primitives/element.ts
@@ -10,7 +10,7 @@
  * @since 1.0.0
  * @module trygg/primitives/element
  */
-import { Cause, Data, Effect, Schema, Scope, SubscriptionRef } from "effect";
+import { Cause, Data, Effect, Layer, Schema, Scope, SubscriptionRef } from "effect";
 import * as Context from "effect/Context";
 import type { Signal } from "./signal.js";
 
@@ -702,6 +702,7 @@ export type Element = Data.TaggedEnum<{
     readonly key: ElementKey | null;
     readonly identity: unknown;
     readonly inputs: unknown;
+    readonly provider?: ComponentProvider | null;
   };
   /**
    * Fragment containing multiple children without a wrapper element
@@ -743,6 +744,11 @@ export type ElementWithRequirements<R> = Element & {
   readonly [ElementRequirementsSymbol]?: R;
 };
 
+export interface ComponentProvider {
+  readonly layer: Layer.Layer<never, unknown, unknown>;
+  readonly displayName: string | undefined;
+}
+
 export type ComponentElement = Extract<Element, { _tag: "Component" }>;
 
 export type ComponentElementWithRequirements<R> = ComponentElement & {
@@ -773,6 +779,7 @@ export interface ComponentElementOptions {
   readonly key?: ElementKey | undefined;
   readonly identity?: unknown;
   readonly inputs?: unknown;
+  readonly provider?: ComponentProvider | undefined;
 }
 
 /**
@@ -837,6 +844,7 @@ const ComponentElementOptionsSchema = Schema.Struct({
   key: Schema.optional(Schema.Union([Schema.String, Schema.Number])),
   identity: Schema.optional(Schema.Any),
   inputs: Schema.optional(Schema.Any),
+  provider: Schema.optional(Schema.Any),
 });
 
 const decodeComponentElementOptions = Schema.decodeUnknownSync<
@@ -872,6 +880,7 @@ export const fromEffect = <E, R>(
     key: decoded.key ?? null,
     identity: decoded.identity,
     inputs: decoded.inputs,
+    provider: decoded.provider ?? null,
   });
 };
 

--- a/packages/core/src/primitives/render-component.ts
+++ b/packages/core/src/primitives/render-component.ts
@@ -3,6 +3,7 @@ import * as Context from "effect/Context";
 import * as Debug from "../debug/debug.js";
 import * as Metrics from "../debug/metrics.js";
 import type { Element } from "./element.js";
+import { unsafeBuildProviderContext } from "../internal/unsafe.js";
 import { Element as ElementService } from "./element.js";
 import * as Signal from "./signal.js";
 import type { RenderContext, RenderResult } from "./renderer.js";
@@ -63,7 +64,7 @@ export const renderComponent = (
   deps: RenderComponentDeps,
 ): Effect.Effect<RenderResult, unknown, unknown> =>
   Effect.gen(function* () {
-    const { run, key, identity, inputs } = component;
+    const { run, key, identity, inputs, provider = null } = component;
     const anchor = document.createComment("component");
     parent.appendChild(anchor);
 
@@ -76,8 +77,40 @@ export const renderComponent = (
     let currentRun = run;
     let currentInputs = inputs;
     let currentContext = context;
+    let providerContext: Context.Context<unknown> | null = null;
 
     const componentScope = yield* Scope.fork(yield* Effect.scope);
+    const providerScope = provider === null ? null : yield* Scope.fork(componentScope);
+    const mergeProviderContext = (parentContext: Context.Context<unknown> | null) =>
+      providerContext === null
+        ? parentContext
+        : Context.merge(deps.normalizeContext(parentContext), providerContext);
+
+    if (provider !== null && providerScope !== null) {
+      const acquireStart = performance.now();
+      providerContext = yield* unsafeBuildProviderContext(
+        provider.layer,
+        providerScope,
+        currentContext,
+      ).pipe(
+        Effect.tapCause((cause) =>
+          Debug.log({
+            event: "provider.failure",
+            component: provider.displayName,
+            reason: "failure",
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      );
+      currentContext = mergeProviderContext(currentContext);
+      yield* Debug.log({
+        event: "provider.acquire",
+        component: provider.displayName,
+        reason: "mount",
+        duration_ms: performance.now() - acquireStart,
+      });
+    }
+
     const renderPhase = yield* Signal.makeRenderPhase;
     const rendererScope = yield* Effect.scope;
     let subscriptionCleanups: Array<Effect.Effect<void, unknown, unknown>> = [];
@@ -335,6 +368,10 @@ export const renderComponent = (
             return false;
           }
 
+          if (resolvedNextElement.provider?.layer !== provider?.layer) {
+            return false;
+          }
+
           const sameIdentity =
             identity !== undefined
               ? resolvedNextElement.identity === identity
@@ -345,14 +382,15 @@ export const renderComponent = (
           }
 
           const inputsChanged = !equalOrChanged(currentInputs, resolvedNextElement.inputs);
+          const effectiveNextContext = mergeProviderContext(resolvedNextContext);
           const contextChanged = !equalOrChanged(
             deps.normalizeContext(currentContext),
-            deps.normalizeContext(resolvedNextContext),
+            deps.normalizeContext(effectiveNextContext),
           );
 
           currentRun = resolvedNextElement.run;
           currentInputs = resolvedNextElement.inputs;
-          currentContext = resolvedNextContext;
+          currentContext = effectiveNextContext;
 
           if (!inputsChanged && !contextChanged) {
             return true;

--- a/packages/core/src/primitives/signal.ts
+++ b/packages/core/src/primitives/signal.ts
@@ -14,7 +14,18 @@
  * @since 1.0.0
  * @module trygg/primitives/signal
  */
-import { Cause, Data, Effect, Equal, Exit, Hash, Ref, Scope, SubscriptionRef } from "effect";
+import {
+  Cause,
+  Data,
+  Effect,
+  Equal,
+  Exit,
+  Hash,
+  Pipeable,
+  Ref,
+  Scope,
+  SubscriptionRef,
+} from "effect";
 import * as Context from "effect/Context";
 import * as Debug from "../debug/debug.js";
 import * as Metrics from "../debug/metrics.js";
@@ -1055,10 +1066,14 @@ const makeSignalElement = (signal: Signal<Element>): SuspendElement =>
 const makeComponentElement = <E, R>(
   run: () => Effect.Effect<SuspendElement, E, R>,
 ): SuspendElement =>
-  ({ _tag: "Component", run, key: null, identity: undefined, inputs: undefined }) satisfies Extract<
-    SuspendElement,
-    { readonly _tag: "Component" }
-  >;
+  ({
+    _tag: "Component",
+    run,
+    key: null,
+    identity: undefined,
+    inputs: undefined,
+    provider: null,
+  }) satisfies Extract<SuspendElement, { readonly _tag: "Component" }>;
 
 const isEffectComponentLike = (
   value: unknown,
@@ -1193,7 +1208,6 @@ export const exhaustive = <Props, E, R>(
   self: SuspendMatcher<Props, E, R, true, true>,
 ): Effect.Effect<SuspendedComponent<Props, E, R>, never> =>
   Effect.gen(function* () {
-    const { tagComponent } = yield* Effect.promise(() => import("./component.js"));
     const pending = self.pending;
     const failure = self.failure;
 
@@ -1211,6 +1225,9 @@ export const exhaustive = <Props, E, R>(
           _tag: "EffectComponent",
           _layers: self.component._layers,
           _signal: makeSync(makeTextElement("Signal.suspend unavailable")),
+          pipe() {
+            return Pipeable.pipeArguments(this, arguments);
+          },
         },
       );
     }
@@ -1340,7 +1357,9 @@ export const exhaustive = <Props, E, R>(
       _layers: self.component._layers,
       _runFn: runFn,
       _signal: initialSignal,
-      provide: tagComponent(suspendedComponent, self.component._layers, runFn).provide,
+      pipe() {
+        return Pipeable.pipeArguments(this, arguments);
+      },
     });
   });
 

--- a/packages/core/src/router/__tests__/middleware-builder.test.ts
+++ b/packages/core/src/router/__tests__/middleware-builder.test.ts
@@ -11,7 +11,6 @@ import * as Route from "../route.js";
 class TestError extends Data.TaggedError("TestError")<{ readonly message: string }> {}
 import { empty } from "../../primitives/element.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 
 // Helper to create dummy RouteComponent
 const makeComp = (): RouteComponent => {
@@ -19,8 +18,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<LayerTypes.Any>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/outlet-boundaries.test.ts
+++ b/packages/core/src/router/__tests__/outlet-boundaries.test.ts
@@ -23,7 +23,6 @@ import {
 } from "../matching.js";
 import { empty } from "../../primitives/element.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 import type { Any as AnyLayer } from "effect/Layer";
 
 // Helper to create dummy RouteComponent
@@ -32,8 +31,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };
@@ -45,8 +45,9 @@ const makeNamedComp = (name: string): RouteComponent => {
     _tag: "EffectComponent" as const,
     _name: name,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/outlet-matching.test.ts
+++ b/packages/core/src/router/__tests__/outlet-matching.test.ts
@@ -20,7 +20,6 @@ import * as Router from "../service.js";
 import * as Signal from "../../primitives/signal.js";
 import { empty } from "../../primitives/element.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 import type { Any as AnyLayer } from "effect/Layer";
 
 // Helper to create dummy RouteComponent
@@ -29,8 +28,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/outlet-middleware.test.ts
+++ b/packages/core/src/router/__tests__/outlet-middleware.test.ts
@@ -18,7 +18,6 @@ import * as Routes from "../routes.js";
 import { createMatcher, collectRouteMiddleware, runRouteMiddleware } from "../matching.js";
 import { empty } from "../../primitives/element.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 import type { Any as AnyLayer } from "effect/Layer";
 
 class TestMiddlewareError extends Data.TaggedError("TestMiddlewareError")<{
@@ -31,8 +30,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/outlet-navigation.test.tsx
+++ b/packages/core/src/router/__tests__/outlet-navigation.test.tsx
@@ -32,7 +32,6 @@ import { Element } from "../../index.js";
 import * as Signal from "../../primitives/signal.js";
 import { AsyncLoader } from "../outlet-services.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 import { unsafeEraseR } from "../../internal/unsafe.js";
 import type { Any as AnyLayer, Layer as LayerType } from "effect/Layer";
 
@@ -56,8 +55,9 @@ const identifiableComp = (testId: string, content: string): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };
@@ -78,8 +78,9 @@ const loadingComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/outlet-rendering.test.ts
+++ b/packages/core/src/router/__tests__/outlet-rendering.test.ts
@@ -24,7 +24,6 @@ import { Element, text } from "../../primitives/element.js";
 import type { ElementKey } from "../../primitives/element.js";
 import { getFiberRef, setFiberRef } from "../../internal/fiber-ref.js";
 import { InvalidRouteComponent, type RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 
 // =============================================================================
 // Helper: Create RouteComponent
@@ -36,8 +35,9 @@ const textComp = (content: string): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<LayerTypes.Any>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };
@@ -58,8 +58,9 @@ const layoutComp = (_name: string): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<LayerTypes.Any>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/path-params.test.ts
+++ b/packages/core/src/router/__tests__/path-params.test.ts
@@ -8,7 +8,6 @@ import * as Route from "../route.js";
 import { createMatcher } from "../matching.js";
 import { empty } from "../../primitives/element.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 import type { Any as AnyLayer } from "effect/Layer";
 
 // Helper to create dummy RouteComponent
@@ -17,8 +16,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/prefetch-modules.test.ts
+++ b/packages/core/src/router/__tests__/prefetch-modules.test.ts
@@ -8,7 +8,6 @@
 import { assert, describe, it } from "@effect/vitest";
 import { Effect, Ref } from "effect";
 import type { Any as AnyLayer } from "effect/Layer";
-import * as Component from "../../primitives/component.js";
 import { empty } from "../../primitives/element.js";
 import * as Route from "../route.js";
 import * as Routes from "../routes.js";
@@ -26,8 +25,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/__tests__/route-builder.test.ts
+++ b/packages/core/src/router/__tests__/route-builder.test.ts
@@ -13,7 +13,6 @@ import { RenderStrategy } from "../render-strategy.js";
 import { ScrollStrategy } from "../scroll-strategy.js";
 import { empty } from "../../primitives/element.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 import type { Any as AnyLayer } from "effect/Layer";
 
 // Helper to create dummy RouteComponent
@@ -22,8 +21,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };
@@ -387,27 +387,24 @@ describe("Route.provide", () => {
     assert.strictEqual(route.definition.scrollStrategy, ScrollStrategy.None);
   });
 
-  it("should store unknown layers in layers array", () => {
-    // Use a fresh layer not in the known sets (Layer.effect creates a new instance)
-    const FreshLayer = Layer.effect(RenderStrategy, Effect.succeed({ _tag: "Lazy" as const }));
+  it("should not store route service layers", () => {
+    class AuthService extends Context.Service<AuthService, { readonly userId: string }>()(
+      "AuthService",
+    ) {}
+    const AuthLive = Layer.succeed(AuthService)({ userId: "test" });
 
-    const route = Route.make("/").component(component).pipe(Route.provide(FreshLayer));
-
-    assert.strictEqual(route.definition.layers.length, 1);
-    assert.strictEqual(route.definition.layers[0], FreshLayer);
+    // @ts-expect-error Route.provide only accepts RenderStrategy and ScrollStrategy layers.
+    Route.provide(AuthLive);
   });
 
-  it("should combine strategy layers and other layers", () => {
-    const FreshLayer = Layer.effect(RenderStrategy, Effect.succeed({ _tag: "Lazy" as const }));
-
+  it("should combine only strategy layers", () => {
     const route = Route.make("/")
       .component(component)
-      .pipe(Route.provide(RenderStrategy.Eager, FreshLayer, ScrollStrategy.None));
+      .pipe(Route.provide(RenderStrategy.Eager, ScrollStrategy.None));
 
     assert.strictEqual(route.definition.renderStrategy, RenderStrategy.Eager);
     assert.strictEqual(route.definition.scrollStrategy, ScrollStrategy.None);
-    assert.strictEqual(route.definition.layers.length, 1);
-    assert.strictEqual(route.definition.layers[0], FreshLayer);
+    assert.strictEqual(route.definition.layers.length, 0);
   });
 
   it("should return a RouteBuilder (not an Effect)", () => {
@@ -429,85 +426,29 @@ describe("Route.provide", () => {
     assert.strictEqual(route.definition.renderStrategy, RenderStrategy.Eager);
   });
 
-  it("should narrow R when providing service layers", () => {
-    // Type equality check - fails compilation if types don't match
+  it("should keep middleware requirements on the route", () => {
     type Equals<X, Y> =
       (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 
-    // Create a service
     class AuthService extends Context.Service<AuthService, { readonly userId: string }>()(
       "AuthService",
     ) {}
-    const AuthLive = Layer.succeed(AuthService)({ userId: "test" });
 
-    // Middleware that requires AuthService
     const requireAuth = Effect.gen(function* () {
       const auth = yield* AuthService;
       if (!auth.userId) return yield* Effect.fail("unauthorized");
     });
 
-    // Route with middleware (R = AuthService)
-    const routeWithRequirement = Route.make("/protected")
+    const route = Route.make("/protected")
       .middleware(requireAuth)
-      .component(component);
-
-    // Type-level assertion: before provide, R includes AuthService
-    type BeforeR =
-      typeof routeWithRequirement extends Route.RouteBuilder<
-        infer _P,
-        infer R,
-        infer _HC,
-        infer _HCh
-      >
-        ? R
-        : never;
-    const _beforeCheck: Equals<BeforeR, AuthService> = true;
-
-    // After provide, R should be never (AuthService is satisfied)
-    const routeProvided = routeWithRequirement.pipe(Route.provide(AuthLive));
-
-    // Type-level assertion: after provide, R is never
-    type AfterR =
-      typeof routeProvided extends Route.RouteBuilder<infer _P, infer R, infer _HC, infer _HCh>
-        ? R
-        : never;
-    const _afterCheck: Equals<AfterR, never> = true;
-
-    // Suppress unused variable warnings
-    void _beforeCheck;
-    void _afterCheck;
-
-    // Runtime check: layer was stored
-    assert.strictEqual(routeProvided.definition.layers.length, 1);
-    assert.strictEqual(routeProvided.definition.layers[0], AuthLive);
-  });
-
-  it("should narrow R with multiple service layers", () => {
-    type Equals<X, Y> =
-      (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
-
-    class ServiceA extends Context.Service<ServiceA, { readonly a: string }>()("ServiceA") {}
-    class ServiceB extends Context.Service<ServiceB, { readonly b: number }>()("ServiceB") {}
-
-    const LayerA = Layer.succeed(ServiceA)({ a: "test" });
-    const LayerB = Layer.succeed(ServiceB)({ b: 42 });
-
-    const middleware = Effect.gen(function* () {
-      yield* ServiceA;
-      yield* ServiceB;
-    });
-
-    const route = Route.make("/multi")
-      .middleware(middleware)
       .component(component)
-      .pipe(Route.provide(LayerA, LayerB));
+      .pipe(Route.provide(RenderStrategy.Eager));
 
-    // Type-level: after provide, R should be never
     type R =
       typeof route extends Route.RouteBuilder<infer _P, infer R, infer _HC, infer _HCh> ? R : never;
-    const _check: Equals<R, never> = true;
+    const _check: Equals<R, AuthService> = true;
     void _check;
 
-    assert.strictEqual(route.definition.layers.length, 2);
+    assert.strictEqual(route.definition.layers.length, 0);
   });
 });

--- a/packages/core/src/router/__tests__/routes-collection.test.ts
+++ b/packages/core/src/router/__tests__/routes-collection.test.ts
@@ -9,7 +9,6 @@ import * as Route from "../route.js";
 import * as Routes from "../routes.js";
 import { empty } from "../../primitives/element.js";
 import type { RouteComponent } from "../types.js";
-import type { Component } from "../../primitives/component.js";
 import type { Any as AnyLayer } from "effect/Layer";
 
 // Helper to create dummy RouteComponent
@@ -18,8 +17,9 @@ const makeComp = (): RouteComponent => {
   const comp = Object.assign(fn, {
     _tag: "EffectComponent" as const,
     _layers: [] as ReadonlyArray<AnyLayer>,
-
-    provide: () => comp as Component.Type<never, unknown, unknown>,
+    pipe() {
+      return this;
+    },
   });
   return comp as RouteComponent;
 };

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -183,7 +183,7 @@ import { currentRoute as _currentRoute } from "./service.js";
 
 /**
  * Route namespace - provides `Route.make(path)`, `Route.index(component)`,
- * `Route.provide(...layers)`, `Route.current`, `Route.redirect(path)`,
+ * `Route.provide(...strategies)`, `Route.current`, `Route.redirect(path)`,
  * and `Route.forbidden()`.
  *
  * @remarks

--- a/packages/core/src/router/route.ts
+++ b/packages/core/src/router/route.ts
@@ -592,67 +592,65 @@ export const isRouteBuilder = (
   typeof value === "object" && value !== null && RouteBuilderTypeId in value;
 
 // =============================================================================
-// Route.provide — Layer Application
+// Route.provide — Strategy Application
 // =============================================================================
 
 /** Known RenderStrategy layer instances for detection. @internal */
-const KNOWN_RENDER_STRATEGIES = new Set<LayerTypes.Any>([
+const KNOWN_RENDER_STRATEGIES = new Set<LayerTypes.Layer<RenderStrategy>>([
   RenderStrategy.Lazy,
   RenderStrategy.Eager,
 ]);
 
 /** Known ScrollStrategy layer instances for detection. @internal */
-const KNOWN_SCROLL_STRATEGIES = new Set<LayerTypes.Any>([ScrollStrategy.Auto, ScrollStrategy.None]);
+const KNOWN_SCROLL_STRATEGIES = new Set<LayerTypes.Layer<ScrollStrategy>>([
+  ScrollStrategy.Auto,
+  ScrollStrategy.None,
+]);
 
 /** @internal */
-const isRenderStrategyLayer = (layer: LayerTypes.Any): layer is LayerTypes.Layer<RenderStrategy> =>
-  KNOWN_RENDER_STRATEGIES.has(layer);
+type RouteStrategyLayer =
+  | LayerTypes.Layer<RenderStrategy, never, never>
+  | LayerTypes.Layer<ScrollStrategy, never, never>;
 
 /** @internal */
-const isScrollStrategyLayer = (layer: LayerTypes.Any): layer is LayerTypes.Layer<ScrollStrategy> =>
-  KNOWN_SCROLL_STRATEGIES.has(layer);
+const isRenderStrategyLayer = (
+  layer: RouteStrategyLayer,
+): layer is LayerTypes.Layer<RenderStrategy, never, never> =>
+  KNOWN_RENDER_STRATEGIES.has(layer as LayerTypes.Layer<RenderStrategy>);
 
-/** @internal Distributive helper to extract layer's provided services */
-type LayerSuccess<L> = L extends LayerTypes.Layer<infer A, infer _E, infer _R> ? A : never;
-/** @internal Distributive helper to extract layer's requirements */
-type LayerContext<L> = L extends LayerTypes.Layer<infer _A, infer _E, infer R> ? R : never;
+/** @internal */
+const isScrollStrategyLayer = (
+  layer: RouteStrategyLayer,
+): layer is LayerTypes.Layer<ScrollStrategy, never, never> =>
+  KNOWN_SCROLL_STRATEGIES.has(layer as LayerTypes.Layer<ScrollStrategy>);
 
 /**
- * Apply Layers to a route. Detects layer type and stores appropriately:
+ * Apply strategy layers to a route:
  * - `RenderStrategy` layer -> stored as render strategy
  * - `ScrollStrategy` layer -> stored as scroll strategy
- * - Other layers -> stored for middleware R requirements (narrows R type)
  *
- * Used with `.pipe()`:
+ * @example
  * ```tsx
  * Route.make("/")
  *   .component(HomePage)
  *   .pipe(Route.provide(RenderStrategy.Eager))
  *
  * Route.make("/settings")
- *   .middleware(requireAuth)
- *   .children(...)
- *   .pipe(Route.provide(AuthLive, ScrollStrategy.None))
+ *   .component(SettingsPage)
+ *   .pipe(Route.provide(RenderStrategy.Eager, ScrollStrategy.None))
  * ```
  *
  * @remarks
- * `provide` attaches route-local layers without breaking the fluent builder
- * flow. Strategy layers go to dedicated fields while other layers stay on the
- * definition for middleware requirements.
- *
- * @example
- * ```tsx
- * Route.make("/settings")
- *   .component(SettingsPage)
- *   .pipe(Route.provide(AuthLive, ScrollStrategy.None))
- * ```
+ * `provide` attaches route-local strategy layers without breaking the fluent
+ * builder flow. Component data/services belong at component lifecycle
+ * boundaries via `Component.provide(layer)`.
  *
  * @category Route Builders
  * @public
  * @since 1.0.0
  */
-export function provide<ROut, E2 = never, RIn = never>(
-  layer: LayerTypes.Layer<ROut, E2, RIn>,
+export function provide(
+  layer: RouteStrategyLayer,
 ): <
   Path extends string,
   R,
@@ -662,27 +660,19 @@ export function provide<ROut, E2 = never, RIn = never>(
   HEB extends boolean,
 >(
   builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
-) => RouteBuilder<Path, RIn | Exclude<R, ROut>, HC, HCh, NC, HEB>;
+) => RouteBuilder<Path, R, HC, HCh, NC, HEB>;
 
 /**
- * Apply multiple Layers to a route.
- *
- * @remarks
- * Use this overload when a route needs more than one layer and you want the
- * builder to carry the combined requirements.
+ * Apply multiple strategy layers to a route.
  *
  * @category Route Builders
  * @public
  * @since 1.0.0
  */
-export function provide<
-  L1 extends LayerTypes.Any,
-  L2 extends LayerTypes.Any,
-  Rest extends LayerTypes.Any[],
->(
-  layer1: L1,
-  layer2: L2,
-  ...rest: Rest
+export function provide(
+  layer1: RouteStrategyLayer,
+  layer2: RouteStrategyLayer,
+  ...rest: Array<RouteStrategyLayer>
 ): <
   Path extends string,
   R,
@@ -692,17 +682,10 @@ export function provide<
   HEB extends boolean,
 >(
   builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
-) => RouteBuilder<
-  Path,
-  LayerContext<L1 | L2 | Rest[number]> | Exclude<R, LayerSuccess<L1 | L2 | Rest[number]>>,
-  HC,
-  HCh,
-  NC,
-  HEB
->;
+) => RouteBuilder<Path, R, HC, HCh, NC, HEB>;
 
 export function provide(
-  ...layers: ReadonlyArray<LayerTypes.Any>
+  ...layers: ReadonlyArray<RouteStrategyLayer>
 ): <
   Path extends string,
   R,
@@ -712,7 +695,7 @@ export function provide(
   HEB extends boolean,
 >(
   builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
-) => RouteBuilder<Path, unknown, HC, HCh, NC, HEB> {
+) => RouteBuilder<Path, R, HC, HCh, NC, HEB> {
   return <
     Path extends string,
     R,
@@ -722,28 +705,25 @@ export function provide(
     HEB extends boolean,
   >(
     builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
-  ): RouteBuilder<Path, unknown, HC, HCh, NC, HEB> => {
+  ): RouteBuilder<Path, R, HC, HCh, NC, HEB> => {
     let renderStrategy: LayerTypes.Layer<RenderStrategy> | undefined =
       builder.definition.renderStrategy;
     let scrollStrategy: LayerTypes.Layer<ScrollStrategy> | undefined =
       builder.definition.scrollStrategy;
-    const otherLayers: Array<LayerTypes.Any> = [...builder.definition.layers];
 
     for (const layer of layers) {
       if (isRenderStrategyLayer(layer)) {
         renderStrategy = layer;
       } else if (isScrollStrategyLayer(layer)) {
         scrollStrategy = layer;
-      } else {
-        otherLayers.push(layer);
       }
     }
 
-    return makeBuilder<Path, unknown, HC, HCh, NC, HEB>({
+    return makeBuilder<Path, R, HC, HCh, NC, HEB>({
       ...builder.definition,
       renderStrategy,
       scrollStrategy,
-      layers: otherLayers,
+      layers: builder.definition.layers,
     });
   };
 }


### PR DESCRIPTION
## Summary
- Add pipeable `Component.provide(layer)` and remove the component method/array provision path.
- Store provider metadata on component elements so the renderer can acquire provider layers with component-owned scopes.
- Reuse provider contexts across stable rerenders and finalize provider scopes with the mounted component lifecycle.
- Narrow `Route.provide` to render/scroll strategy layers and update route tests for service-layer rejection.

## DX impact
Before:
```tsx
const App = Component.gen(function* () {
  return <Dashboard />
}).provide(AppLive)
```

After:
```tsx
const App = Component.gen(function* () {
  return <Dashboard />
}).pipe(Component.provide(AppLive))
```

## Acceptance criteria
- [x] `Component.provide(layer)` is pipeable/data-last.
- [x] Provider layer acquisition is scoped to the mounted component lifecycle.
- [x] Stable component rerenders reuse the provider context.
- [x] Legacy component method/array provision is rejected/migrated.
- [x] Route provision is strategy-only.
- [x] Focused primitive/router tests pass.

## Weird spots / attention notes
- Provider-context casts are quarantined in `packages/core/src/internal/unsafe.ts`.
- Provider layer identity changes intentionally force remount instead of reconciliation.
- This PR is based on `checkpoint-issue-187-base` to keep the #187 diff reviewable; the base branch is only the pre-work checkpoint requested before implementation.

## Validation
- `bun run --cwd packages/core typecheck`
- focused primitive/router suite: 295 tests passed
- full repo validation is green in the stack tip PR.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#206** 👈 current
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->