### PR TITLE
docs: migrate provision examples

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "effect"]
-	path = effect
-	url = https://github.com/Effect-TS/effect-smol
 [submodule ".repos/effect"]
 	path = .repos/effect
 	url = https://github.com/Effect-TS/effect-smol

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const Greeting = Component.gen(function* () {
   const theme = yield* Theme
   const name = yield* Signal.make("world")
   return <h1 style={{ color: theme.primary }}>Hello, {name}!</h1>
-}).provide(themeLayer)
+}).pipe(Component.provide(themeLayer))
 ```
 
 ## Features

--- a/apps/examples/app/components/error-boundary/risky-component.tsx
+++ b/apps/examples/app/components/error-boundary/risky-component.tsx
@@ -33,4 +33,4 @@ export const RiskyComponent = Component.gen(function* (
   }
 
   return <SuccessDisplay />;
-}).provide(defaultErrorTheme);
+}).pipe(Component.provide(defaultErrorTheme));

--- a/apps/examples/app/layout.tsx
+++ b/apps/examples/app/layout.tsx
@@ -117,4 +117,4 @@ export default Component.gen(function* () {
       </body>
     </html>
   );
-}).provide(ApiClientLive);
+}).pipe(Component.provide(ApiClientLive));

--- a/apps/examples/app/pages/counter.tsx
+++ b/apps/examples/app/pages/counter.tsx
@@ -10,8 +10,8 @@ const defaultTheme = Layer.succeed(CounterTheme, {
   text: "#1e40af",
 });
 
-const ProvidedCounterButton = CounterButton.provide(defaultTheme);
-const ProvidedCountDisplay = CountDisplay.provide(defaultTheme);
+const ProvidedCounterButton = CounterButton.pipe(Component.provide(defaultTheme));
+const ProvidedCountDisplay = CountDisplay.pipe(Component.provide(defaultTheme));
 
 const CounterPage = Component.gen(function* () {
   const count = yield* Signal.make(0);

--- a/apps/examples/app/pages/dashboard.tsx
+++ b/apps/examples/app/pages/dashboard.tsx
@@ -68,11 +68,20 @@ const DashboardPage = Component.gen(function* () {
 
   // Partial provision: provide services based on current signal state
   // Components have different requirements, so we provide different layer combinations
-  const ProvidedHeader = Header.provide([currentTheme, loggerLayer]);
-  const ProvidedStatCard = StatCard.provide(currentTheme);
-  const ProvidedActionButton = ActionButton.provide([currentTheme, analyticsLayer]);
-  const ProvidedSectionTitle = SectionTitle.provide(currentTheme);
-  const ProvidedActivityItem = ActivityItem.provide([currentTheme, analyticsLayer]);
+  const ProvidedHeader = Header.pipe(
+    Component.provide(currentTheme),
+    Component.provide(loggerLayer),
+  );
+  const ProvidedStatCard = StatCard.pipe(Component.provide(currentTheme));
+  const ProvidedActionButton = ActionButton.pipe(
+    Component.provide(currentTheme),
+    Component.provide(analyticsLayer),
+  );
+  const ProvidedSectionTitle = SectionTitle.pipe(Component.provide(currentTheme));
+  const ProvidedActivityItem = ActivityItem.pipe(
+    Component.provide(currentTheme),
+    Component.provide(analyticsLayer),
+  );
 
   return (
     <div className="min-h-screen font-sans -m-6 p-0" style={{ background: theme.background }}>

--- a/apps/examples/app/pages/error-boundary.tsx
+++ b/apps/examples/app/pages/error-boundary.tsx
@@ -77,6 +77,6 @@ const ErrorBoundaryPage = Component.gen(function* () {
       </div>
     </div>
   );
-}).provide(defaultErrorTheme);
+}).pipe(Component.provide(defaultErrorTheme));
 
 export default ErrorBoundaryPage;

--- a/apps/examples/app/pages/form.tsx
+++ b/apps/examples/app/pages/form.tsx
@@ -164,6 +164,6 @@ const FormPage = Component.gen(function* () {
       )}
     </div>
   );
-}).provide(defaultFormTheme);
+}).pipe(Component.provide(defaultFormTheme));
 
 export default FormPage;

--- a/apps/examples/app/pages/nested-provide.tsx
+++ b/apps/examples/app/pages/nested-provide.tsx
@@ -1,7 +1,7 @@
 /**
  * Nested Provide Demo
  *
- * Demonstrates nested Component.provide() where child components access
+ * Demonstrates nested Component.provide(layer) where child components access
  * services from multiple ancestor layers. The key scenario: an event handler
  * that accesses an ancestor service at click time (not captured in a closure).
  *
@@ -82,7 +82,7 @@ const StyledSection = Component.gen(function* (
   }>,
 ) {
   const { label, name, style } = yield* Props;
-  const Provided = GreetingCard.provide(style);
+  const Provided = GreetingCard.pipe(Component.provide(style));
 
   return (
     <div>
@@ -130,7 +130,7 @@ const NestedProvidePage = Component.gen(function* () {
   const idx = yield* Signal.get(localeIndex);
   const locale = locales[idx] ?? locales[0];
 
-  const LocaleSection = StyledSection.provide(locale.layer);
+  const LocaleSection = StyledSection.pipe(Component.provide(locale.layer));
 
   return (
     <div>

--- a/apps/examples/app/pages/suspend.tsx
+++ b/apps/examples/app/pages/suspend.tsx
@@ -145,6 +145,6 @@ const SuspendPage = Component.gen(function* () {
       </div>
     </div>
   );
-}).provide(SuspendUiLive);
+}).pipe(Component.provide(SuspendUiLive));
 
 export default SuspendPage;

--- a/apps/examples/app/pages/theme.tsx
+++ b/apps/examples/app/pages/theme.tsx
@@ -36,6 +36,6 @@ const ThemeExample = Component.gen(function* () {
   );
 });
 
-const ThemePage = ThemeExample.provide(ThemeStoreLive);
+const ThemePage = ThemeExample.pipe(Component.provide(ThemeStoreLive));
 
 export default ThemePage;

--- a/apps/examples/app/pages/todo.tsx
+++ b/apps/examples/app/pages/todo.tsx
@@ -19,8 +19,8 @@ const defaultTodoTheme = Layer.succeed(TodoTheme, {
   primaryColor: "#0066cc",
 });
 
-const ProvidedTodoInput = TodoInput.provide(defaultTodoTheme);
-const ProvidedFilterButton = FilterButton.provide(defaultTodoTheme);
+const ProvidedTodoInput = TodoInput.pipe(Component.provide(defaultTodoTheme));
+const ProvidedFilterButton = FilterButton.pipe(Component.provide(defaultTodoTheme));
 
 const TodoPage = Component.gen(function* () {
   const todos = yield* Signal.make<ReadonlyArray<Todo>>([]);

--- a/apps/www/app/__contracts__/docs-lazy-route-commits-shell.contract.tsx
+++ b/apps/www/app/__contracts__/docs-lazy-route-commits-shell.contract.tsx
@@ -168,8 +168,9 @@ const runScenario = Effect.scoped(
       );
     });
 
+    const context = yield* Effect.context<never>();
     const LazyResourcesPage = () =>
-      Effect.runPromise(
+      Effect.runPromiseWith(context)(
         Effect.gen(function* () {
           yield* Deferred.succeed(moduleRequested, void 0);
           yield* Deferred.await(releaseModule);

--- a/apps/www/app/__contracts__/home-workbench-types.contract.tsx
+++ b/apps/www/app/__contracts__/home-workbench-types.contract.tsx
@@ -77,7 +77,7 @@ const users = Resource.make(
 const UsersPage = Component.gen(function* () {
   const state = yield* Resource.fetch(users);
   return <UserList state={state} />;
-}).provide(ApiClientLive);
+}).pipe(Component.provide(ApiClientLive));
 
 // ---------------------------------------------------------------------------
 // Type assertions — the tooltips in home.tsx claim these signatures.
@@ -133,7 +133,7 @@ type _UserListR = AssertTrue<
   >
 >;
 
-// `.provide(ApiClientLive)` should remove ApiClient from R.
+// `.pipe(Component.provide(ApiClientLive))` should remove ApiClient from R.
 type _UsersPageDoesNotRequireApiClient = AssertTrue<
   Types.Equals<
     typeof UsersPage extends Component.Type<infer _P, infer _E, infer R> ? R : never,

--- a/apps/www/app/components/code-block.tsx
+++ b/apps/www/app/components/code-block.tsx
@@ -6,7 +6,13 @@
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
 import { Effect } from "effect";
-import { Component, Portal, Signal, type ComponentProps } from "trygg";
+import {
+  Component,
+  Portal,
+  Signal,
+  type ComponentProps,
+  type Element as TryggElement,
+} from "trygg";
 import type { Element as HastElement, Text as HastText, RootContent, Root as HastRoot } from "hast";
 
 import { getTheme, type Theme } from "../lib/theme";
@@ -307,7 +313,7 @@ export function hastChildToJsx(node: HastNode, key: number, options: HastRenderO
         const matches = isStringLiteral || isJsxText ? [] : [...text.matchAll(pattern)];
         if (matches.length > 0) {
           const prefix = options.tooltipIdPrefix ?? "code-tip";
-          const parts: Array<JSX.Element> = [];
+          const parts: Array<TryggElement> = [];
           let lastIndex = 0;
           let partIndex = 0;
           for (const m of matches) {

--- a/apps/www/app/content/copy.ts
+++ b/apps/www/app/content/copy.ts
@@ -113,7 +113,7 @@ export const sections = {
 export default Component.gen(function* () {
   const state = yield* Resource.fetch(users);
   return <UserList state={state} />;
-}).provide(ApiClientLive);`,
+}).pipe(Component.provide(ApiClientLive));`,
       },
     ],
     continueHref: "/docs/getting-started",

--- a/apps/www/app/examples/getting-started.tsx
+++ b/apps/www/app/examples/getting-started.tsx
@@ -21,4 +21,4 @@ export default Component.gen(function* () {
       </button>
     </main>
   );
-}).provide(ThemeLive);
+}).pipe(Component.provide(ThemeLive));

--- a/apps/www/app/examples/themed-greeting.tsx
+++ b/apps/www/app/examples/themed-greeting.tsx
@@ -27,4 +27,4 @@ const ThemeLive = Layer.succeed(Theme, {
   greeting: "Hello",
 });
 
-export default Greeting.provide(ThemeLive);
+export default Greeting.pipe(Component.provide(ThemeLive));

--- a/apps/www/app/global.d.ts
+++ b/apps/www/app/global.d.ts
@@ -7,6 +7,11 @@ declare module "*.md?raw" {
   export default content;
 }
 
+declare module "*.tsx?raw" {
+  const content: string;
+  export default content;
+}
+
 declare module "*.css";
 
 interface ImportMeta {

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -79,7 +79,7 @@ export default Component.gen(function* () {
 
         {/* Fonts */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
           href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@700&display=swap"
           rel="stylesheet"

--- a/apps/www/app/pages/docs/page.tsx
+++ b/apps/www/app/pages/docs/page.tsx
@@ -1,6 +1,5 @@
 import { Component, Signal } from "trygg";
 import * as Router from "trygg/router";
-
 import { docsHeadings } from "../../content/headings";
 import { sidebarGroups } from "../../content/sidebar";
 

--- a/apps/www/app/pages/home.tsx
+++ b/apps/www/app/pages/home.tsx
@@ -2,7 +2,7 @@
  * Home Page: trygg.dev — Variant A (The Workbench)
  */
 import { Effect, Result, Scope } from "effect";
-import { Component, Signal, type ComponentProps } from "trygg";
+import { Component, Signal, type ComponentProps, type Element as TryggElement } from "trygg";
 import * as Router from "trygg/router";
 
 import {
@@ -172,11 +172,11 @@ const EditorPanel = Component.gen(function* (
   Props: ComponentProps<{
     readonly id: WorkbenchView;
     readonly active: Signal.Signal<WorkbenchView>;
-    readonly children: JSX.Element;
+    readonly children: TryggElement;
   }>,
 ) {
   const { id, active, children } = yield* Props;
-  const className = yield* Signal.derive(active, (view) =>
+  const className = yield* Signal.derive<WorkbenchView, string>(active, (view) =>
     view === id ? "home-workbench__panel home-workbench__panel--active" : "home-workbench__panel",
   );
 
@@ -196,7 +196,7 @@ const SidebarFile = Component.gen(function* (
   }>,
 ) {
   const { id, label, active, onSelect } = yield* Props;
-  const className = yield* Signal.derive(active, (view) => {
+  const className = yield* Signal.derive<WorkbenchView, string>(active, (view) => {
     const isActive = view === id;
     return isActive ? "home-workbench__file home-workbench__file--active" : "home-workbench__file";
   });
@@ -375,19 +375,15 @@ const Workbench = Component.gen(function* () {
   const highlightedByTheme = yield* Effect.promise(
     async (): Promise<Record<Theme, ReadonlyArray<ReadonlyArray<HighlightedLine>>>> => {
       const themes: ReadonlyArray<Theme> = ["dark", "light"];
-      const entries = await Promise.all(
-        themes.map(async (entryTheme) => {
-          const steps = await Promise.all(
+      const [dark, light] = await Promise.all(
+        themes.map((entryTheme) =>
+          Promise.all(
             sections.seam.steps.map((step) => highlightCode(step.code, "tsx", entryTheme)),
-          );
-          return [entryTheme, steps] as const;
-        }),
+          ),
+        ),
       );
 
-      return Object.fromEntries(entries) as Record<
-        Theme,
-        ReadonlyArray<ReadonlyArray<HighlightedLine>>
-      >;
+      return { dark, light };
     },
   );
 

--- a/apps/www/changelogs/2026-02-05-canary-dependency-fixes.md
+++ b/apps/www/changelogs/2026-02-05-canary-dependency-fixes.md
@@ -5,17 +5,17 @@ version: "trygg@0.1.0-canary.1"
 
 ## Summary
 
-The canary updates scaffolded project dependencies to published package versions and clarifies the generated app setup.
+This canary makes generated projects installable outside the Trygg workspace and clarifies the scaffolded app setup.
 
 ## Changed
 
-- `create-trygg` now emits the published `trygg@^0.1.0-canary.1` dependency and shared Effect/tooling versions instead of `workspace:*`, so scaffolded projects install outside the repo.
-- `create-trygg` now uses clearer platform and output prompts and relies on generated project files instead of stale template files.
-- The `trygg` README now documents the CLI-generated project structure and source-owned setup docs instead of manual mounting; see the [core README](../../../packages/core/README.md).
+- Emit published `trygg@^0.1.0-canary.1` and shared Effect/tooling versions from `create-trygg` instead of `workspace:*`, so scaffolded projects install outside the repo.
+- Clarify `create-trygg` platform and output prompts and rely on generated project files instead of stale template files.
+- Document the CLI-generated project structure and source-owned setup docs in the `trygg` README instead of manual mounting; see the [core README](../../../packages/core/README.md).
 
 ## Fixed
 
-- `create-trygg` now uses current Effect platform package versions for the CLI and generated projects, avoiding stale scaffold dependencies.
+- Use current Effect platform package versions in `create-trygg` and generated projects, avoiding stale scaffold dependencies.
 
 ## Versions
 

--- a/apps/www/changelogs/2026-02-05-initial-canary-release.md
+++ b/apps/www/changelogs/2026-02-05-initial-canary-release.md
@@ -5,22 +5,22 @@ version: "trygg@0.1.0-canary.0"
 
 ## Summary
 
-The first trygg canary publishes the Effect-native JSX framework, router, Vite plugin, testing utilities, examples, and project scaffolder.
+The first Trygg canary publishes the Effect-native JSX framework, router, Vite plugin, testing utilities, examples, and project scaffolder.
 
 ## Added
 
-- `trygg` now provides the core Effect-native component model, JSX runtime, fine-grained `Signal` reactivity, keyed rendering, `Resource` data fetching, `ErrorBoundary`, `Portal`, `Head`, debug events, and metrics; see the [core README](../../../packages/core/README.md).
-- `trygg/router` now provides route builders, typed params and query decoding, middleware, redirects, forbidden responses, nested outlets, loading and error boundaries, scroll strategies, prefetch support, browser navigation, and in-memory test routing; see the [router guide](../../../packages/core/src/router/router.docs.md).
-- `trygg/vite-plugin` now configures the JSX runtime, generates app entry files and route types, serves Effect HttpApi routes in development, and supports static and server builds; see the [Vite plugin guide](../../../packages/core/src/vite/plugin.docs.md).
-- `create-trygg` now scaffolds Bun or Node projects with server or static output, optional Git or Jujutsu setup, generated config files, router templates, API templates, and dependency installation.
-- The examples app now demonstrates counters, dashboards, forms, resources, suspended views, portals, route layouts, protected routes, API routes, and service-provided state.
+- Add the core `trygg` Effect-native component model, JSX runtime, fine-grained `Signal` reactivity, keyed rendering, `Resource` data fetching, `ErrorBoundary`, `Portal`, `Head`, debug events, and metrics; see the [core README](../../../packages/core/README.md).
+- Add `trygg/router` route builders, typed params and query decoding, middleware, redirects, forbidden responses, nested outlets, loading and error boundaries, scroll strategies, prefetch support, browser navigation, and in-memory test routing; see the [router guide](../../../packages/core/src/router/router.docs.md).
+- Add `trygg/vite-plugin` support for JSX runtime configuration, generated app entry files and route types, Effect HttpApi development routes, and static or server builds; see the [Vite plugin guide](../../../packages/core/src/vite/plugin.docs.md).
+- Add `create-trygg` scaffolding for Bun or Node projects with server or static output, optional Git or Jujutsu setup, generated config files, router templates, API templates, and dependency installation.
+- Add examples for counters, dashboards, forms, resources, suspended views, portals, route layouts, protected routes, API routes, and service-provided state.
 
 ## Fixed
 
-- `Component.provide` now merges parent and child context instead of replacing it, preserving services supplied higher in the tree.
-- `Signal.suspend` now handles error paths without crashing while suspended work resolves.
-- JSX component elements now preserve `key`, so keyed list and component identity behave consistently.
-- API middleware, schema decode failures, error boundaries, dev-mode cleanup, router requirement narrowing, and canary publish tagging were hardened before the release.
+- Merge parent and child context in `Component.provide` instead of replacing it, preserving services supplied higher in the tree.
+- Handle `Signal.suspend` error paths without crashing while suspended work resolves.
+- Preserve JSX component `key` values so keyed list and component identity behave consistently.
+- Harden API middleware, schema decode failures, error boundaries, dev-mode cleanup, router requirement narrowing, and canary publish tagging before the release.
 
 ## Versions
 

--- a/apps/www/changelogs/2026-02-08-incident-dashboard-template.md
+++ b/apps/www/changelogs/2026-02-08-incident-dashboard-template.md
@@ -5,29 +5,29 @@ version: "trygg@0.2.0-canary.0"
 
 ## Summary
 
-The canary adds selectable project templates, a full-stack incident dashboard scaffold, reactive route activity signals, and renderer fixes for keyed lists and boundaries.
-
-## Added
-
-- `create-trygg` now lets new projects choose a Blank App or Incident Dashboard template, so teams can start from either a minimal app or a full-stack example.
-- The Incident Dashboard template now includes API routes, incident resources, report forms, detail and settings pages, route boundaries, theme state, command palette UI, and static assets.
-- `trygg/testing` is now a package entrypoint for Effect-native render helpers, DOM event helpers, and waits; see the [testing guide](../../../packages/core/src/testing/testing.docs.md).
+This canary adds selectable project templates, a full-stack incident dashboard scaffold, reactive route activity signals, and renderer fixes for keyed lists and boundaries.
 
 ## Changed
 
-- Breaking: `Router.isActive` now returns `Signal<boolean>` instead of a boolean, enabling fine-grained active-link updates without rerendering route components; see the [router service guide](../../../packages/core/src/router/service.docs.md).
-- Breaking: `Signal.unsafeMake` is now `Signal.makeSync`, clarifying that synchronous signals are for module-lifetime state and service-backed globals; see the [signal guide](../../../packages/core/src/primitives/signal.docs.md).
-- Breaking: Testing helpers now import from `trygg/testing` instead of the root `trygg` entrypoint.
-- `Link` now forwards user `data-*` and `aria-*` attributes to the underlying anchor, supporting active-state attributes derived from `Router.isActive`; see the [link guide](../../../packages/core/src/router/link.docs.md).
-- Route builders now track schema-decoded route params and query requirements through error-boundary coverage, surfacing missing route boundaries at typecheck time; see the [route guide](../../../packages/core/src/router/route.docs.md).
-- The Vite plugin now exposes a plugin shape that avoids app-local Vite type identity conflicts; see the [Vite plugin guide](../../../packages/core/src/vite/plugin.docs.md).
+- **Breaking:** Return `Signal<boolean>` from `Router.isActive` instead of a boolean, enabling fine-grained active-link updates without rerendering route components; see the [router service guide](../../../packages/core/src/router/service.docs.md).
+- **Breaking:** Rename `Signal.unsafeMake` to `Signal.makeSync`, clarifying that synchronous signals are for module-lifetime state and service-backed globals; see the [signal guide](../../../packages/core/src/primitives/signal.docs.md).
+- **Breaking:** Move testing helper imports from the root `trygg` entrypoint to `trygg/testing`.
+- Forward user `data-*` and `aria-*` attributes from `Link` to the underlying anchor, supporting active-state attributes derived from `Router.isActive`; see the [link guide](../../../packages/core/src/router/link.docs.md).
+- Track schema-decoded route params and query requirements through route builders and error-boundary coverage, surfacing missing route boundaries at typecheck time; see the [route guide](../../../packages/core/src/router/route.docs.md).
+- Expose a Vite plugin shape that avoids app-local Vite type identity conflicts; see the [Vite plugin guide](../../../packages/core/src/vite/plugin.docs.md).
+
+## Added
+
+- Add Blank App and Incident Dashboard template choices to `create-trygg`, so teams can start from either a minimal app or a full-stack example.
+- Add an Incident Dashboard template with API routes, incident resources, report forms, detail and settings pages, route boundaries, theme state, command palette UI, and static assets.
+- Add the `trygg/testing` package entrypoint for Effect-native render helpers, DOM event helpers, and waits; see the [testing guide](../../../packages/core/src/testing/testing.docs.md).
 
 ## Fixed
 
-- `Signal.each` now preserves keyed item DOM ranges during reorder and rerender, preventing fragment moves from dropping content or flashing stale rows.
-- `ErrorBoundary` now mounts fallback content before cleaning up the failed render, avoiding blank states when an error races with DOM placement.
-- Signal-valued attributes now update document-rendered elements, so reactive attributes stay current outside normal element children.
-- Blank static scaffolds no longer keep an unnecessary server API file.
+- Preserve keyed item DOM ranges in `Signal.each` during reorder and rerender, preventing fragment moves from dropping content or flashing stale rows.
+- Mount `ErrorBoundary` fallback content before cleaning up the failed render, avoiding blank states when an error races with DOM placement.
+- Update signal-valued attributes on document-rendered elements, so reactive attributes stay current outside normal element children.
+- Remove the unnecessary server API file from blank static scaffolds.
 
 ## Versions
 

--- a/apps/www/changelogs/2026-02-10-script-defer-attribute.md
+++ b/apps/www/changelogs/2026-02-10-script-defer-attribute.md
@@ -5,15 +5,11 @@ version: "trygg@0.2.0-canary.1"
 
 ## Summary
 
-JSX script elements now accept the `defer` attribute, so apps can type deferred script loading without escaping the `ElementProps` surface.
-
-```tsx
-<script src="/analytics.js" defer />
-```
+JSX script elements accept the `defer` attribute, so apps can type deferred script loading without escaping the `ElementProps` surface.
 
 ## Added
 
-- `ElementProps` now includes the `defer` script attribute with reactive boolean support; see the [Element docs](../../../packages/core/src/primitives/element.docs.md).
+- Add the `defer` script attribute to `ElementProps` with reactive boolean support; see the [Element docs](../../../packages/core/src/primitives/element.docs.md).
 
 ## Versions
 

--- a/apps/www/changelogs/2026-03-09-effect-4-reactivity.md
+++ b/apps/www/changelogs/2026-03-09-effect-4-reactivity.md
@@ -7,28 +7,18 @@ version: "trygg@0.2.0-canary.2"
 
 This canary moves the core package onto the Effect 4 beta line and updates reactive async APIs so suspended views and resources keep type information and stale UI through refreshes.
 
-```tsx
-const SuspendedProfile =
-  yield *
-  Signal.suspend(UserProfile).pipe(
-    Signal.on("Pending", Spinner),
-    Signal.on("Failure", ErrorView),
-    Signal.exhaustive,
-  );
-```
-
 ## Changed
 
-- Breaking: `Signal.suspend` now uses pipeable `Signal.on` and `Signal.exhaustive` handlers, preserving component props, errors, and requirements through suspended views; see the [Signal docs](../../../packages/core/src/primitives/signal.docs.md).
-- Breaking: `Resource.match` now supports pipeable `Resource.on` and `Resource.exhaustive` handlers for exhaustive async state rendering; see the [Resource docs](../../../packages/core/src/primitives/resource.docs.md).
-- Breaking: `trygg` now targets Effect 4 beta peer packages, replacing the Effect 3 peer dependency set used by `trygg@0.2.0-canary.1`.
+- **Breaking:** Replace `Signal.suspend` match objects with pipeable `Signal.on` and `Signal.exhaustive` handlers, preserving component props, errors, and requirements through suspended views; see the [Signal docs](../../../packages/core/src/primitives/signal.docs.md).
+- **Breaking:** Add pipeable `Resource.on` and `Resource.exhaustive` handlers to `Resource.match` for exhaustive async state rendering; see the [Resource docs](../../../packages/core/src/primitives/resource.docs.md).
+- **Breaking:** Target Effect 4 beta peer packages from `trygg`, replacing the Effect 3 peer dependency set used by `trygg@0.2.0-canary.1`.
 
 ## Fixed
 
-- Signal state now stays stable when Vite loads duplicated Trygg modules during development.
-- Router prefetch now runs render-triggered prefetches after the link render pass, avoiding render-phase interference.
-- `Resource.match` now keeps stale successful data available while pending or failed states render fallback UI.
-- `Signal.suspend` now keeps stale rendered output by dependency key and reacts to signal changes without dropping component requirements.
+- Keep Signal state stable when Vite loads duplicated Trygg modules during development.
+- Run router prefetches triggered by render after the link render pass, avoiding render-phase interference.
+- Keep stale successful data available in `Resource.match` while pending or failed states render fallback UI.
+- Preserve stale `Signal.suspend` output by dependency key and react to signal changes without dropping component requirements.
 
 ## Versions
 

--- a/apps/www/changelogs/2026-04-28-generated-api-client.md
+++ b/apps/www/changelogs/2026-04-28-generated-api-client.md
@@ -19,7 +19,7 @@ const incidents = Resource.make(
       return yield* client.incidents.list();
     }),
   { key: "incidents.list" },
-).provide(ApiClientLive);
+).pipe(Component.provide(ApiClientLive));
 ```
 
 ## Added

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -18,7 +18,7 @@
     "alchemy": "2.0.0-beta.25",
     "effect": "4.0.0-beta.58",
     "shiki": "^3.22.0",
-    "trygg": "^0.4.0-canary.1",
+    "trygg": "workspace:*",
     "vitest": "^4.1.5"
   },
   "devDependencies": {

--- a/docs/agents/trygg-ui.md
+++ b/docs/agents/trygg-ui.md
@@ -1,6 +1,6 @@
 # Trygg UI Patterns
 
 - Components use `Component.gen(function* () { ... })`.
-- Children yield services; parents provide them with `.provide(layer)`.
+- Children yield services; parents provide them with `.pipe(Component.provide(layer))`.
 - The top-level effect passed to mount must have `R = never`.
 - Event handlers are effect thunks: `() => Effect.Effect<void>`.

--- a/packages/cli/src/__tests__/scaffold.test.ts
+++ b/packages/cli/src/__tests__/scaffold.test.ts
@@ -183,6 +183,31 @@ describe("scaffoldProject", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeFileSystemLayer)),
   );
 
+  it.effect("blank scaffold demonstrates Component.gen with Theme service", () =>
+    Effect.gen(function* () {
+      // Scope: verifies the default blank app teaches trygg DI basics.
+      // Assertion: generated home page uses Component.gen, a Theme service, and service injection.
+      const fs = yield* FileSystem.FileSystem;
+      const targetDir = yield* fs.makeTempDirectory({
+        directory: WORKSPACE_TEMP_DIR,
+        prefix: "trygg-scaffold-test-",
+      });
+      yield* Effect.addFinalizer(() =>
+        fs.remove(targetDir, { recursive: true }).pipe(Effect.ignore),
+      );
+
+      yield* runScaffold(targetDir, "blank");
+
+      const homePath = path.join(targetDir, "app", "pages", "home.tsx");
+      const homeContent = yield* fs.readFileString(homePath);
+
+      assert.include(homeContent, "Component.gen");
+      assert.include(homeContent, "class Theme extends Context.Service");
+      assert.include(homeContent, "yield* Theme");
+      assert.include(homeContent, "Layer.succeed(Theme");
+    }).pipe(Effect.scoped, Effect.provide(NodeFileSystemLayer)),
+  );
+
   it.effect("blank scaffold should typecheck and build successfully", () =>
     Effect.gen(function* () {
       // Scope: verifies a freshly scaffolded blank app works without any API setup.
@@ -263,6 +288,43 @@ describe("scaffoldProject", () => {
         const output = `${buildResult.stdout}\n${buildResult.stderr}`;
         assert.include(output, "app/api.ts must export Api");
       }).pipe(Effect.scoped, Effect.provide(NodeFileSystemLayer)),
+  );
+
+  it.effect("blank scaffold home uses Component.gen and Theme service", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const targetDir = yield* fs.makeTempDirectory({ prefix: "trygg-scaffold-test-" });
+      yield* Effect.addFinalizer(() =>
+        fs.remove(targetDir, { recursive: true }).pipe(Effect.ignore),
+      );
+
+      yield* runScaffold(targetDir, "blank");
+
+      const homePath = path.join(targetDir, "app", "pages", "home.tsx");
+      const homeContent = yield* fs.readFileString(homePath);
+
+      assert.include(homeContent, "Component.gen");
+      assert.include(homeContent, "yield* Theme");
+      assert.include(homeContent, "Theme service");
+    }).pipe(Effect.scoped, Effect.provide(NodeFileSystemLayer)),
+  );
+
+  it.effect("blank scaffold layout provides theme layer", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const targetDir = yield* fs.makeTempDirectory({ prefix: "trygg-scaffold-test-" });
+      yield* Effect.addFinalizer(() =>
+        fs.remove(targetDir, { recursive: true }).pipe(Effect.ignore),
+      );
+
+      yield* runScaffold(targetDir, "blank");
+
+      const layoutPath = path.join(targetDir, "app", "layout.tsx");
+      const layoutContent = yield* fs.readFileString(layoutPath);
+
+      assert.include(layoutContent, "ThemeLive");
+      assert.include(layoutContent, ".pipe(Component.provide(ThemeLive))");
+    }).pipe(Effect.scoped, Effect.provide(NodeFileSystemLayer)),
   );
 
   it.effect(

--- a/packages/cli/templates/incident/app/components/command-palette.tsx
+++ b/packages/cli/templates/incident/app/components/command-palette.tsx
@@ -106,7 +106,7 @@ export const CommandPalette = Component.gen(function* (Props: ComponentProps<Com
   );
 
   // Subscribe to open state and sync with dialog
-  yield* Signal.subscribe(open, () =>
+  const unsubscribeOpen = yield* Signal.subscribe(open, () =>
     Effect.gen(function* () {
       const node = document.getElementById(DIALOG_ID);
       if (!(node instanceof HTMLDialogElement)) {
@@ -128,6 +128,7 @@ export const CommandPalette = Component.gen(function* (Props: ComponentProps<Com
       }
     }),
   );
+  yield* Effect.addFinalizer(() => unsubscribeOpen);
 
   // Event handlers
   const onQueryInput = (event: Event) =>

--- a/packages/cli/templates/incident/app/layout.tsx
+++ b/packages/cli/templates/incident/app/layout.tsx
@@ -141,4 +141,4 @@ export default Component.gen(function* () {
       </body>
     </html>
   );
-}).provide([AppThemeDark, ApiClientLive]);
+}).pipe(Component.provide(AppThemeDark), Component.provide(ApiClientLive));

--- a/packages/cli/templates/incident/app/services/theme.ts
+++ b/packages/cli/templates/incident/app/services/theme.ts
@@ -129,9 +129,9 @@ const make = (fallback: ThemeMode): Layer.Layer<AppTheme> =>
     AppTheme,
     Effect.gen(function* () {
       const initialPreference = yield* readStoredPreference;
-      const preference = Signal.makeSync<ThemePreference>(initialPreference);
+      const preference = yield* Signal.make<ThemePreference>(initialPreference);
       const initialMode = yield* resolveMode(initialPreference, fallback);
-      const mode = Signal.makeSync<ThemeMode>(initialMode);
+      const mode = yield* Signal.make<ThemeMode>(initialMode);
 
       const setPreference = (next: ThemePreference): Effect.Effect<void> =>
         Effect.gen(function* () {

--- a/packages/core/src/api/api.docs.md
+++ b/packages/core/src/api/api.docs.md
@@ -25,14 +25,19 @@ The generated client uses same-origin `baseUrl: ""` by default. Provide `ApiClie
 ```ts
 import { ApiClient, ApiClientLive } from "trygg/api";
 
-const users = Resource.make(
-  () =>
-    Effect.gen(function* () {
-      const client = yield* ApiClient;
-      return yield* client.users.list();
-    }),
-  { key: "users.list" },
-).provide(ApiClientLive);
+const UsersPage = Component.gen(function* () {
+  const users = Resource.make(
+    () =>
+      Effect.gen(function* () {
+        const client = yield* ApiClient;
+        return yield* client.users.list();
+      }),
+    { key: "users.list" },
+  );
+
+  const state = yield* Resource.fetch(users);
+  return <UserList state={state} />;
+}).pipe(Component.provide(ApiClientLive));
 ```
 
 ### Required `export const Api`

--- a/packages/core/src/primitives/component.docs.md
+++ b/packages/core/src/primitives/component.docs.md
@@ -2,7 +2,7 @@
 
 ## When to use
 
-Use `Component` when UI needs explicit Effect requirements, parent-provided services, typed props, or local `Signal` state. It is the right surface for forms, service-backed pages, and trees where parents satisfy child requirements with `.provide(layer)`.
+Use `Component` when UI needs explicit Effect requirements, parent-provided services, typed props, or local `Signal` state. It is the right surface for forms, service-backed pages, and trees where parents satisfy child requirements with `Component.provide(layer)`.
 
 ## Behavior
 
@@ -144,7 +144,7 @@ const ValidatedForm = Component.gen(function* () {
 });
 ```
 
-For dependency injection, children `yield*` services and parents decide where to provide them. Each `.provide(layer)` narrows the remaining `R`; by the time an app reaches `mount`, the root effect must have `R = never`.
+For dependency injection, children `yield*` services and parents decide where to provide them. Each `.pipe(Component.provide(layer))` narrows the remaining `R`; by the time an app reaches `mount`, the root effect must have `R = never`.
 
 Complex trees often need multiple interdependent services. Define services with `Context.Tag`, build layers that depend on other layers with `Layer.provideMerge`, and let the type system enforce that every requirement is satisfied before `mount`:
 
@@ -195,7 +195,7 @@ const UserProfile = Component.gen(function* (
 const App = Component.gen(function* () {
   const userId = yield* Signal.make("1");
   return <UserProfile userId={userId} />;
-}).provide(UserRepositoryLive);
+}).pipe(Component.provide(UserRepositoryLive));
 ```
 
 `App` has `R = never` because `UserRepositoryLive` satisfies `UserRepository`, and `UserRepositoryLive` itself is satisfied by `HttpClientLive`. If a layer were missing, the type error would point to the exact unsatisfied tag at the `mount` call.

--- a/packages/core/src/primitives/element.ts
+++ b/packages/core/src/primitives/element.ts
@@ -287,6 +287,7 @@ export interface HtmlProps extends CommonProps, EventProps {
   readonly target?: string;
   readonly rel?: string;
   readonly download?: string | boolean;
+  readonly crossOrigin?: "anonymous" | "use-credentials";
 
   // Meta elements
   readonly content?: string;
@@ -305,6 +306,7 @@ export interface HtmlProps extends CommonProps, EventProps {
   readonly height?: string | number;
   readonly tabIndex?: number;
   readonly title?: string;
+  readonly dateTime?: string;
   readonly role?: string;
 
   // Document-level attributes

--- a/packages/core/src/primitives/renderer.docs.md
+++ b/packages/core/src/primitives/renderer.docs.md
@@ -8,7 +8,7 @@ Use `mount` for normal apps, `mountDocument` for root-layout ownership, and `Ren
 
 The renderer turns `Element` trees into DOM, preserves render scope for event handlers and subscriptions, and installs the browser/runtime layers needed for signals, resources, and routing.
 
-`mount` is also the service boundary: the app passed to it must already have `R = never`. In practice, children `yield*` services, parents satisfy them with `.provide(layer)`, and the final root effect is what you mount.
+`mount` is also the service boundary: the app passed to it must already have `R = never`. In practice, children `yield*` services, parents satisfy them with `Component.provide(layer)`, and the final root effect is what you mount.
 
 ```tsx
 import { Effect, Layer } from "effect";
@@ -22,10 +22,12 @@ const Header = Component.gen(function* () {
   return <h1>{yield* api.ping}</h1>;
 });
 
-const App = Header.provide(
-  Layer.succeed(Api, {
-    ping: Effect.succeed("ready"),
-  }),
+const App = Header.pipe(
+  Component.provide(
+    Layer.succeed(Api, {
+      ping: Effect.succeed("ready"),
+    }),
+  ),
 );
 ```
 

--- a/packages/core/src/primitives/resource.docs.md
+++ b/packages/core/src/primitives/resource.docs.md
@@ -61,10 +61,12 @@ const UserPanel = Component.gen(function* (
   );
 });
 
-const App = UserPanel.provide(
-  Layer.succeed(UsersApi, {
-    getUser: (id) => Effect.succeed({ id, name: `User ${id}` }),
-  }),
+const App = UserPanel.pipe(
+  Component.provide(
+    Layer.succeed(UsersApi, {
+      getUser: (id) => Effect.succeed({ id, name: `User ${id}` }),
+    }),
+  ),
 );
 ```
 

--- a/packages/core/src/router/outlet-services.ts
+++ b/packages/core/src/router/outlet-services.ts
@@ -49,10 +49,6 @@ import {
 import { CurrentRouteQuery } from "./route.js";
 import { unsafeEraseR } from "../internal/unsafe.js";
 
-const routeComponentWrapperIdentity = Symbol("trygg/router/OutletRenderer.component");
-const routeLayoutWrapperIdentity = Symbol("trygg/router/OutletRenderer.layout");
-const routeErrorWrapperIdentity = Symbol("trygg/router/OutletRenderer.error");
-
 export interface RouteRenderIdentity {
   readonly path: string;
 }
@@ -131,40 +127,48 @@ const isStaleRouteRender = (routeIdentity: RouteRenderIdentity | undefined) =>
 const wrapElementWithFiberRefs = (
   element: ElementType,
   wrapRun: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>,
+  wrapperInputs: unknown,
 ): ElementType => {
   switch (element._tag) {
     case "Component":
       return Element.fromEffect(
         Effect.suspend(() =>
           wrapRun(element.run()).pipe(
-            Effect.map((child) => wrapElementWithFiberRefs(child, wrapRun)),
+            Effect.map((child) => wrapElementWithFiberRefs(child, wrapRun, wrapperInputs)),
             unsafeEraseR,
           ),
         ),
         {
           key: element.key ?? undefined,
           identity: element.identity ?? element.run,
-          inputs: element.inputs,
+          inputs: { element: element.inputs, wrapper: wrapperInputs },
         },
       );
     case "Provide":
-      return provideElement(element.context, wrapElementWithFiberRefs(element.child, wrapRun));
+      return provideElement(
+        element.context,
+        wrapElementWithFiberRefs(element.child, wrapRun, wrapperInputs),
+      );
     case "Intrinsic":
       return Element.Intrinsic({
         tag: element.tag,
         props: element.props,
-        children: element.children.map((child) => wrapElementWithFiberRefs(child, wrapRun)),
+        children: element.children.map((child) =>
+          wrapElementWithFiberRefs(child, wrapRun, wrapperInputs),
+        ),
         key: element.key,
       });
     case "Fragment":
       return Element.Fragment({
-        children: element.children.map((child) => wrapElementWithFiberRefs(child, wrapRun)),
+        children: element.children.map((child) =>
+          wrapElementWithFiberRefs(child, wrapRun, wrapperInputs),
+        ),
       });
     case "Portal":
       return Element.Portal({
         target: element.target,
         children: mapChildInputElements(element.children, (child) =>
-          wrapElementWithFiberRefs(child, wrapRun),
+          wrapElementWithFiberRefs(child, wrapRun, wrapperInputs),
         ),
       });
     case "KeyedList":
@@ -174,21 +178,21 @@ const wrapElementWithFiberRefs = (
         renderFn: (item, index) =>
           element
             .renderFn(item, index)
-            .pipe(Effect.map((child) => wrapElementWithFiberRefs(child, wrapRun))),
+            .pipe(Effect.map((child) => wrapElementWithFiberRefs(child, wrapRun, wrapperInputs))),
       });
     case "ErrorBoundaryElement":
       if (typeof element.fallback === "function") {
         const fallback = element.fallback;
         return Element.ErrorBoundaryElement({
-          child: wrapElementWithFiberRefs(element.child, wrapRun),
-          fallback: (cause) => wrapElementWithFiberRefs(fallback(cause), wrapRun),
+          child: wrapElementWithFiberRefs(element.child, wrapRun, wrapperInputs),
+          fallback: (cause) => wrapElementWithFiberRefs(fallback(cause), wrapRun, wrapperInputs),
           onError: element.onError,
         });
       }
 
       return Element.ErrorBoundaryElement({
-        child: wrapElementWithFiberRefs(element.child, wrapRun),
-        fallback: wrapElementWithFiberRefs(element.fallback, wrapRun),
+        child: wrapElementWithFiberRefs(element.child, wrapRun, wrapperInputs),
+        fallback: wrapElementWithFiberRefs(element.fallback, wrapRun, wrapperInputs),
         onError: element.onError,
       });
     default:
@@ -501,10 +505,19 @@ export function renderComponent(
 
         const capturedContext = yield* Effect.context<unknown>();
         const element = yield* effect;
-        return provideElement(capturedContext, wrapElementWithFiberRefs(element, withRouteContext));
+        const wrapperInputs = {
+          params,
+          query: decodedQuery,
+          routeIdentity,
+          wrappedIdentity: component,
+        };
+        return provideElement(
+          capturedContext,
+          wrapElementWithFiberRefs(element, withRouteContext, wrapperInputs),
+        );
       }).pipe(unsafeEraseR),
       {
-        identity: routeComponentWrapperIdentity,
+        identity: component,
         inputs: { params, query: decodedQuery, routeIdentity, wrappedIdentity: component },
       },
     );
@@ -557,13 +570,20 @@ export function renderLayout(
 
         const capturedContext = yield* Effect.context<unknown>();
         const element = yield* effect;
+        const wrapperInputs = {
+          child,
+          params,
+          query: decodedQuery,
+          routeIdentity,
+          wrappedIdentity: layout,
+        };
         return provideElement(
           capturedContext,
-          wrapElementWithFiberRefs(element, withLayoutContext),
+          wrapElementWithFiberRefs(element, withLayoutContext, wrapperInputs),
         );
       }).pipe(unsafeEraseR),
       {
-        identity: routeLayoutWrapperIdentity,
+        identity: layout,
         inputs: { child, params, query: decodedQuery, routeIdentity, wrappedIdentity: layout },
       },
     );
@@ -608,13 +628,14 @@ export function renderError(
           Effect.gen(function* () {
             const capturedContext = yield* Effect.context<unknown>();
             const element = yield* effect;
+            const wrapperInputs = { cause, path, wrappedIdentity: errorComp };
             return provideElement(
               capturedContext,
-              wrapElementWithFiberRefs(element, withErrorContext),
+              wrapElementWithFiberRefs(element, withErrorContext, wrapperInputs),
             );
           }).pipe(unsafeEraseR),
           {
-            identity: routeErrorWrapperIdentity,
+            identity: errorComp,
             inputs: { cause, path, wrappedIdentity: errorComp },
           },
         );


### PR DESCRIPTION
## Summary
- Migrate README, source-owned docs, website examples, CLI templates, and example app pages from component `.provide(...)` to `.pipe(Component.provide(...))`.
- Update generated-client/home copy expectations affected by the docs refresh.
- Refresh incident template cleanup around signal subscriptions and scoped signal creation.

## DX impact
Before:
```tsx
export default Component.gen(function* () {
  return <App />
}).provide(AppLive)
```

After:
```tsx
export default Component.gen(function* () {
  return <App />
}).pipe(Component.provide(AppLive))
```

## Acceptance criteria
- [x] Public docs show the canonical pipeable provider API.
- [x] CLI templates typecheck with the new provider style.
- [x] Example app component provision call sites are migrated.
- [x] Full repo typecheck/lint/format/test/build validation passes.

## Weird spots / attention notes
- The base branch is PR #206 (`push-yykrlsyovnss`) so this PR reviews only docs/examples/template migration on top of the core lifecycle changes.

## Validation
- `bun run typecheck`
- `bun run typecheck:templates`
- `bun run lint`
- `bun run format`
- `bun run effect:check`
- `bun run test` (core 1169 tests, www 88 tests)
- `bun run build`
- `bun run --cwd apps/examples build`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. **#207** 👈 current
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->