### PR TITLE
chore(examples): migrate scoped signal stores

### DIFF
--- a/apps/examples/app/components/resource/user-posts.tsx
+++ b/apps/examples/app/components/resource/user-posts.tsx
@@ -16,43 +16,37 @@ export const UserPosts = Component.gen(function* (
     Resource.on("Pending", () => <Skeleton lines={6} />),
     Resource.on(
       "Success",
-      ({ value: posts, stale }: { value: ReadonlyArray<Post>; stale: boolean }) => {
-        const postsSignal = Signal.makeSync(posts);
-
-        return (
-          <div className={cx(stale && "opacity-60")}>
-            <ul className="list-none p-0 m-0">
-              {Signal.each(
-                postsSignal,
-                (post) =>
-                  Effect.succeed(
-                    <li className="p-3 bg-white rounded mb-2 border border-gray-200 last:mb-0">
-                      <strong className="block mb-1 text-gray-700">{post.title}</strong>
-                      <p className="m-0 text-gray-500 text-sm">{post.body}</p>
-                    </li>,
-                  ),
-                { key: (post) => post.id },
-              )}
-              {posts.length === 0 && (
-                <li className="p-3 bg-white rounded mb-2 border border-gray-200">No posts found</li>
-              )}
-            </ul>
-            <div>
-              <button
-                className="text-sm px-3 py-1.5 border border-gray-300 rounded bg-white cursor-pointer transition-colors hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
-                onClick={() =>
-                  Signal.peek(userId).pipe(
-                    Effect.flatMap((id) => Resource.invalidate(userPostsResource({ id }))),
-                  )
-                }
-                disabled={stale}
+      ({ value: posts, stale }: { value: ReadonlyArray<Post>; stale: boolean }) => (
+        <div className={cx(stale && "opacity-60")}>
+          <ul className="list-none p-0 m-0">
+            {posts.map((post) => (
+              <li
+                key={post.id}
+                className="p-3 bg-white rounded mb-2 border border-gray-200 last:mb-0"
               >
-                {stale ? "Refreshing..." : "Refresh"}
-              </button>
-            </div>
+                <strong className="block mb-1 text-gray-700">{post.title}</strong>
+                <p className="m-0 text-gray-500 text-sm">{post.body}</p>
+              </li>
+            ))}
+            {posts.length === 0 && (
+              <li className="p-3 bg-white rounded mb-2 border border-gray-200">No posts found</li>
+            )}
+          </ul>
+          <div>
+            <button
+              className="text-sm px-3 py-1.5 border border-gray-300 rounded bg-white cursor-pointer transition-colors hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
+              onClick={() =>
+                Signal.peek(userId).pipe(
+                  Effect.flatMap((id) => Resource.invalidate(userPostsResource({ id }))),
+                )
+              }
+              disabled={stale}
+            >
+              {stale ? "Refreshing..." : "Refresh"}
+            </button>
           </div>
-        );
-      },
+        </div>
+      ),
     ),
     Resource.on(
       "Failure",
@@ -74,29 +68,24 @@ export const UserPosts = Component.gen(function* (
               }
             />
           ),
-          onSome: (posts) => {
-            const postsSignal = Signal.makeSync(posts);
-            return (
-              <div>
-                <div className="bg-red-50 text-red-800 py-3 px-4 rounded-md flex justify-between items-center text-sm">
-                  Failed to refresh
-                </div>
-                <ul className="list-none p-0 m-0 opacity-60">
-                  {Signal.each(
-                    postsSignal,
-                    (post) =>
-                      Effect.succeed(
-                        <li className="p-3 bg-white rounded mb-2 border border-gray-200 last:mb-0">
-                          <strong className="block mb-1 text-gray-700">{post.title}</strong>
-                          <p className="m-0 text-gray-500 text-sm">{post.body}</p>
-                        </li>,
-                      ),
-                    { key: (post) => post.id },
-                  )}
-                </ul>
+          onSome: (posts) => (
+            <div>
+              <div className="bg-red-50 text-red-800 py-3 px-4 rounded-md flex justify-between items-center text-sm">
+                Failed to refresh
               </div>
-            );
-          },
+              <ul className="list-none p-0 m-0 opacity-60">
+                {posts.map((post) => (
+                  <li
+                    key={post.id}
+                    className="p-3 bg-white rounded mb-2 border border-gray-200 last:mb-0"
+                  >
+                    <strong className="block mb-1 text-gray-700">{post.title}</strong>
+                    <p className="m-0 text-gray-500 text-sm">{post.body}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ),
         }),
     ),
     Resource.exhaustive,

--- a/apps/examples/app/components/resource/users-list.tsx
+++ b/apps/examples/app/components/resource/users-list.tsx
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { Resource, Signal, Component, cx, type ComponentProps } from "trygg";
+import { Resource, Component, cx, type ComponentProps } from "trygg";
 import { usersResource, type User } from "../../resources/users";
 import { Skeleton } from "../skeleton";
 import { ErrorView } from "../error-view";
@@ -14,46 +14,38 @@ export const UsersList = Component.gen(function* (
     Resource.on("Pending", () => <Skeleton lines={4} />),
     Resource.on(
       "Success",
-      ({ value: users, stale }: { value: ReadonlyArray<User>; stale: boolean }) => {
-        const usersSignal = Signal.makeSync(users);
-
-        return (
-          <div
-            className={cx("bg-white rounded-lg p-4 border border-gray-200", stale && "opacity-60")}
-          >
-            <div className="flex justify-between items-center mb-3 pb-3 border-b border-gray-100 text-sm text-gray-500">
-              <span>
-                {users.length} users {stale && "(refreshing...)"}
-              </span>
-              <button
-                className="px-4 py-2 text-base border border-gray-300 rounded bg-white cursor-pointer transition-colors hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
-                onClick={() => Resource.invalidate(usersResource)}
-                disabled={stale}
-              >
-                Refresh
-              </button>
-            </div>
-            <ul className="list-none p-0 m-0">
-              {Signal.each(
-                usersSignal,
-                (user) =>
-                  Effect.succeed(
-                    <li
-                      className="flex justify-between items-center px-3 py-2.5 my-1 rounded-md cursor-pointer transition-colors hover:bg-gray-50"
-                      onClick={() => onSelect(user.id)}
-                    >
-                      <span className="font-medium text-gray-700">{user.name}</span>
-                      <span className="text-xs text-gray-400 bg-gray-100 py-0.5 px-2 rounded">
-                        {user.role}
-                      </span>
-                    </li>,
-                  ),
-                { key: (user) => user.id },
-              )}
-            </ul>
+      ({ value: users, stale }: { value: ReadonlyArray<User>; stale: boolean }) => (
+        <div
+          className={cx("bg-white rounded-lg p-4 border border-gray-200", stale && "opacity-60")}
+        >
+          <div className="flex justify-between items-center mb-3 pb-3 border-b border-gray-100 text-sm text-gray-500">
+            <span>
+              {users.length} users {stale && "(refreshing...)"}
+            </span>
+            <button
+              className="px-4 py-2 text-base border border-gray-300 rounded bg-white cursor-pointer transition-colors hover:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed"
+              onClick={() => Resource.invalidate(usersResource)}
+              disabled={stale}
+            >
+              Refresh
+            </button>
           </div>
-        );
-      },
+          <ul className="list-none p-0 m-0">
+            {users.map((user) => (
+              <li
+                key={user.id}
+                className="flex justify-between items-center px-3 py-2.5 my-1 rounded-md cursor-pointer transition-colors hover:bg-gray-50"
+                onClick={() => onSelect(user.id)}
+              >
+                <span className="font-medium text-gray-700">{user.name}</span>
+                <span className="text-xs text-gray-400 bg-gray-100 py-0.5 px-2 rounded">
+                  {user.role}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ),
     ),
     Resource.on("Failure", ({ error }) => (
       <ErrorView error={error} onRetry={() => Resource.refresh(usersResource)} />

--- a/apps/examples/app/layout.tsx
+++ b/apps/examples/app/layout.tsx
@@ -7,6 +7,7 @@
 import { Component, DevMode } from "trygg";
 import * as Router from "trygg/router";
 import { ApiClientLive } from "trygg/api";
+import { AuthLive } from "./resources/auth";
 import "../styles.css";
 
 export default Component.gen(function* () {
@@ -117,4 +118,4 @@ export default Component.gen(function* () {
       </body>
     </html>
   );
-}).pipe(Component.provide(ApiClientLive));
+}).pipe(Component.provide(ApiClientLive), Component.provide(AuthLive));

--- a/apps/examples/app/pages/login.tsx
+++ b/apps/examples/app/pages/login.tsx
@@ -1,13 +1,14 @@
 import { Effect, Option } from "effect";
 import { Signal, Component } from "trygg";
 import * as Router from "trygg/router";
-import { authSignal, type AuthUser, setAuth } from "../resources/auth";
+import { AuthStore, type AuthUser, setAuth } from "../resources/auth";
 
 const LoginPage = Component.gen(function* () {
   const username = yield* Signal.make("");
   const error = yield* Signal.make<Option.Option<string>>(Option.none());
 
-  const user = yield* Signal.get(authSignal);
+  const auth = yield* AuthStore;
+  const user = yield* Signal.get(auth.user);
 
   const handleLogin = (e: Event) =>
     Effect.gen(function* () {

--- a/apps/examples/app/pages/nested-provide.tsx
+++ b/apps/examples/app/pages/nested-provide.tsx
@@ -1,27 +1,74 @@
 /**
  * Nested Provide Demo
  *
- * Demonstrates nested Component.provide(layer) where child components access
- * services from multiple ancestor layers. The key scenario: an event handler
- * that accesses an ancestor service at click time (not captured in a closure).
+ * Demonstrates stable Component.provide(layer) boundaries where child
+ * components access services from multiple ancestor layers. Interactive locale
+ * state lives inside a lifecycle-provided store instead of swapping provider
+ * layers during render.
  *
  * Layout provides ApiClientLive (grandparent)
- *   -> App provides Locale (parent)
- *     -> Card provides CardStyle (child)
- *       -> button onClick accesses Locale (ancestor) at click time
+ *   -> Page provides LocaleStoreLive (parent)
+ *     -> Card sections provide CardStyle (child)
+ *       -> button onClick accesses LocaleStore at click time
  */
 import { Effect, Layer } from "effect";
 import * as Context from "effect/Context";
 import { Signal, Component, type ComponentProps } from "trygg";
 
 // =============================================================================
-// Services — three layers of context
+// Services — stable provider boundaries plus scoped reactive store state
 // =============================================================================
 
-class Locale extends Context.Service<
-  Locale,
-  { readonly lang: string; readonly greeting: string }
->()("demo/Locale") {}
+type LocaleCode = "en" | "es" | "pt-BR";
+
+interface LocaleOption {
+  readonly code: LocaleCode;
+  readonly label: string;
+  readonly greeting: string;
+}
+
+const localeOptions: ReadonlyArray<LocaleOption> = [
+  { code: "en", label: "English", greeting: "Hello" },
+  { code: "es", label: "Español", greeting: "Hola" },
+  { code: "pt-BR", label: "Português", greeting: "Oi" },
+];
+
+const defaultLocale = localeOptions[0] ?? { code: "en", label: "English", greeting: "Hello" };
+
+const localeForCode = (code: LocaleCode): LocaleOption =>
+  localeOptions.find((locale) => locale.code === code) ?? defaultLocale;
+
+class LocaleStore extends Context.Service<
+  LocaleStore,
+  {
+    readonly selected: Signal.Signal<LocaleCode>;
+    readonly label: Signal.Signal<string>;
+    readonly greeting: Signal.Signal<string>;
+    readonly setLocale: (code: LocaleCode) => Effect.Effect<void>;
+  }
+>()("demo/LocaleStore") {}
+
+const LocaleStoreLive = Layer.effect(
+  LocaleStore,
+  Effect.gen(function* () {
+    const selected = yield* Signal.make<LocaleCode>(defaultLocale.code);
+    const label = yield* Signal.make(defaultLocale.label);
+    const greeting = yield* Signal.make(defaultLocale.greeting);
+
+    return {
+      selected,
+      label,
+      greeting,
+      setLocale: (code) =>
+        Effect.gen(function* () {
+          const next = localeForCode(code);
+          yield* Signal.set(selected, next.code);
+          yield* Signal.set(label, next.label);
+          yield* Signal.set(greeting, next.greeting);
+        }),
+    };
+  }),
+);
 
 class CardStyle extends Context.Service<
   CardStyle,
@@ -29,7 +76,7 @@ class CardStyle extends Context.Service<
 >()("demo/CardStyle") {}
 
 // =============================================================================
-// Leaf component — reads both services, handler accesses Locale at click time
+// Leaf component — reads both services, handler accesses LocaleStore at click time
 // =============================================================================
 
 const GreetingCard = Component.gen(function* (
@@ -37,8 +84,10 @@ const GreetingCard = Component.gen(function* (
 ) {
   const { name } = yield* Props;
   const style = yield* CardStyle;
-  const locale = yield* Locale;
+  const locale = yield* LocaleStore;
   const nameValue = yield* Signal.get(name);
+  const greeting = yield* Signal.get(locale.greeting);
+  const selected = yield* Signal.get(locale.selected);
 
   return (
     <div
@@ -46,21 +95,22 @@ const GreetingCard = Component.gen(function* (
       style={{ background: style.bg, borderColor: style.border }}
     >
       <h3 className="mt-0 text-lg" style={{ color: style.accent }}>
-        {locale.greeting}, {nameValue}!
+        {greeting}, {nameValue}!
       </h3>
       <p className="text-sm text-gray-600 m-0 mb-3">
-        Language: <strong>{locale.lang}</strong> | Accent:{" "}
+        Language: <strong>{selected}</strong> | Accent: {""}
         <strong style={{ color: style.accent }}>{style.accent}</strong>
       </p>
       <button
         className="px-3 py-1.5 rounded border border-gray-300 bg-white text-sm cursor-pointer hover:bg-gray-50"
         onClick={() =>
-          // This handler accesses Locale at click time via Effect.gen.
-          // Before the fix, Runtime.runFork would only get CardStyle context
-          // (inner Provide replaced Locale context instead of merging).
+          // This handler accesses LocaleStore at click time via Effect.gen,
+          // proving ancestor context propagates through nested provider
+          // boundaries into event handlers.
           Effect.gen(function* () {
-            const loc = yield* Locale;
-            globalThis.alert(`[${loc.lang}] ${loc.greeting} from the event handler!`);
+            const currentGreeting = yield* Signal.peek(locale.greeting);
+            const currentLang = yield* Signal.peek(locale.selected);
+            globalThis.alert(`[${currentLang}] ${currentGreeting} from the event handler!`);
           })
         }
       >
@@ -71,29 +121,7 @@ const GreetingCard = Component.gen(function* (
 });
 
 // =============================================================================
-// Mid-level — provides CardStyle, wraps GreetingCard
-// =============================================================================
-
-const StyledSection = Component.gen(function* (
-  Props: ComponentProps<{
-    readonly label: string;
-    readonly name: Signal.Signal<string>;
-    readonly style: Layer.Layer<CardStyle>;
-  }>,
-) {
-  const { label, name, style } = yield* Props;
-  const Provided = GreetingCard.pipe(Component.provide(style));
-
-  return (
-    <div>
-      <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-2">{label}</h4>
-      <Provided name={name} />
-    </div>
-  );
-});
-
-// =============================================================================
-// Page — provides Locale, nests StyledSections with different CardStyles
+// Mid-level — stable CardStyle provider boundaries
 // =============================================================================
 
 const OceanStyle = Layer.succeed(CardStyle, {
@@ -114,32 +142,66 @@ const ForestStyle = Layer.succeed(CardStyle, {
   accent: "#15803d",
 });
 
-const EnglishLocale = Layer.succeed(Locale, { lang: "en", greeting: "Hello" });
-const SpanishLocale = Layer.succeed(Locale, { lang: "es", greeting: "Hola" });
-const PortugueseLocale = Layer.succeed(Locale, { lang: "pt-BR", greeting: "Oi" });
+const OceanGreetingCard = GreetingCard.pipe(Component.provide(OceanStyle));
+const SunsetGreetingCard = GreetingCard.pipe(Component.provide(SunsetStyle));
+const ForestGreetingCard = GreetingCard.pipe(Component.provide(ForestStyle));
 
-const locales = [
-  { label: "English", layer: EnglishLocale },
-  { label: "Español", layer: SpanishLocale },
-  { label: "Português", layer: PortugueseLocale },
-];
+const OceanSection = Component.gen(function* (
+  Props: ComponentProps<{ readonly name: Signal.Signal<string> }>,
+) {
+  const { name } = yield* Props;
+
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-2">Ocean</h4>
+      <OceanGreetingCard name={name} />
+    </div>
+  );
+});
+
+const SunsetSection = Component.gen(function* (
+  Props: ComponentProps<{ readonly name: Signal.Signal<string> }>,
+) {
+  const { name } = yield* Props;
+
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-2">Sunset</h4>
+      <SunsetGreetingCard name={name} />
+    </div>
+  );
+});
+
+const ForestSection = Component.gen(function* (
+  Props: ComponentProps<{ readonly name: Signal.Signal<string> }>,
+) {
+  const { name } = yield* Props;
+
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-2">Forest</h4>
+      <ForestGreetingCard name={name} />
+    </div>
+  );
+});
+
+// =============================================================================
+// Page — provides LocaleStore, nests sections with different CardStyles
+// =============================================================================
 
 const NestedProvidePage = Component.gen(function* () {
   const name = yield* Signal.make("World");
-  const localeIndex = yield* Signal.make(0);
-  const idx = yield* Signal.get(localeIndex);
-  const locale = locales[idx] ?? locales[0];
-
-  const LocaleSection = StyledSection.pipe(Component.provide(locale.layer));
+  const locale = yield* LocaleStore;
+  const selected = yield* Signal.get(locale.selected);
+  const selectedLabel = yield* Signal.get(locale.label);
 
   return (
     <div>
       <h2 className="m-0 mb-1 text-xl font-semibold">Nested Provide</h2>
       <p className="text-gray-500 m-0 mb-6 text-sm">
-        Three layers of services with dynamic layer switching. Locale swaps at runtime via signal —
-        each click rebuilds the component tree with a new layer. The "Greet from handler" button
-        accesses Locale at click time via Effect.gen, proving the ancestor context propagates
-        through nested Provide elements into event handlers.
+        Stable provider boundaries supply services; locale changes are scoped signal state inside
+        LocaleStoreLive. Updating the locale rerenders the cards without rebuilding provider layers
+        during render.
       </p>
 
       <div className="flex gap-3 mb-6">
@@ -156,42 +218,25 @@ const NestedProvidePage = Component.gen(function* () {
             return Effect.void;
           }}
         />
-        <button
-          className={`px-3 py-1.5 rounded border text-sm cursor-pointer transition-colors ${
-            idx === 0
-              ? "bg-gray-800 text-white border-gray-800"
-              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-          }`}
-          onClick={() => Signal.set(localeIndex, 0)}
-        >
-          English
-        </button>
-        <button
-          className={`px-3 py-1.5 rounded border text-sm cursor-pointer transition-colors ${
-            idx === 1
-              ? "bg-gray-800 text-white border-gray-800"
-              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-          }`}
-          onClick={() => Signal.set(localeIndex, 1)}
-        >
-          Español
-        </button>
-        <button
-          className={`px-3 py-1.5 rounded border text-sm cursor-pointer transition-colors ${
-            idx === 2
-              ? "bg-gray-800 text-white border-gray-800"
-              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-          }`}
-          onClick={() => Signal.set(localeIndex, 2)}
-        >
-          Português
-        </button>
+        {localeOptions.map((option) => (
+          <button
+            key={option.code}
+            className={`px-3 py-1.5 rounded border text-sm cursor-pointer transition-colors ${
+              selected === option.code
+                ? "bg-gray-800 text-white border-gray-800"
+                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+            }`}
+            onClick={() => locale.setLocale(option.code)}
+          >
+            {option.label}
+          </button>
+        ))}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <LocaleSection label="Ocean" name={name} style={OceanStyle} />
-        <LocaleSection label="Sunset" name={name} style={SunsetStyle} />
-        <LocaleSection label="Forest" name={name} style={ForestStyle} />
+        <OceanSection name={name} />
+        <SunsetSection name={name} />
+        <ForestSection name={name} />
       </div>
 
       <div className="mt-6 p-4 bg-gray-50 rounded-lg border border-gray-200 text-xs text-gray-500 font-mono leading-relaxed">
@@ -199,14 +244,14 @@ const NestedProvidePage = Component.gen(function* () {
           <strong>Context stack:</strong>
         </p>
         <p className="m-0">Layout → ApiClientLive (grandparent)</p>
-        <p className="m-0 ml-4">→ Locale [{locale.label}] (parent — switchable)</p>
-        <p className="m-0 ml-8">→ CardStyle [Ocean|Sunset|Forest] (child — per section)</p>
+        <p className="m-0 ml-4">→ LocaleStoreLive [{selectedLabel}] (parent)</p>
+        <p className="m-0 ml-8">→ CardStyle [Ocean|Sunset|Forest] (child)</p>
         <p className="m-0 ml-12">
-          → GreetingCard reads both + handler accesses Locale at click time
+          → GreetingCard reads both + handler accesses LocaleStore at click time
         </p>
       </div>
     </div>
   );
 });
 
-export default NestedProvidePage;
+export default NestedProvidePage.pipe(Component.provide(LocaleStoreLive));

--- a/apps/examples/app/pages/protected.tsx
+++ b/apps/examples/app/pages/protected.tsx
@@ -1,10 +1,11 @@
 import { Effect, Option } from "effect";
 import { Signal, Component } from "trygg";
 import * as Router from "trygg/router";
-import { authSignal, setAuth } from "../resources/auth";
+import { AuthStore, setAuth } from "../resources/auth";
 
 const ProtectedPage = Component.gen(function* () {
-  const user = yield* Signal.get(authSignal);
+  const auth = yield* AuthStore;
+  const user = yield* Signal.get(auth.user);
 
   if (Option.isNone(user)) {
     return <div>Loading...</div>;

--- a/apps/examples/app/resources/auth.ts
+++ b/apps/examples/app/resources/auth.ts
@@ -1,4 +1,5 @@
-import { Effect, Option } from "effect";
+import { Effect, Layer, Option } from "effect";
+import * as Context from "effect/Context";
 import { Signal } from "trygg";
 import * as Router from "trygg/router";
 
@@ -7,28 +8,49 @@ export interface AuthUser {
   readonly name: string;
 }
 
-/**
- * Global auth signal - in a real app this would be a proper service
- */
-export const authSignal = Signal.makeSync<Option.Option<AuthUser>>(Option.none());
+export class AuthStore extends Context.Service<
+  AuthStore,
+  {
+    readonly user: Signal.Signal<Option.Option<AuthUser>>;
+    readonly setAuth: (user: Option.Option<AuthUser>) => Effect.Effect<void>;
+    readonly getAuth: Effect.Effect<Option.Option<AuthUser>>;
+  }
+>()("examples/AuthStore") {}
 
 /**
- * Helper to set auth state
+ * Auth state lives in a provided scoped service so it follows the app lifecycle.
  */
-export const setAuth = (user: Option.Option<AuthUser>): Effect.Effect<void> =>
-  Signal.set(authSignal, user);
+export const AuthLive = Layer.effect(
+  AuthStore,
+  Effect.gen(function* () {
+    const user = yield* Signal.make<Option.Option<AuthUser>>(Option.none());
+    return {
+      user,
+      setAuth: (nextUser: Option.Option<AuthUser>) => Signal.set(user, nextUser),
+      getAuth: Signal.peek(user),
+    };
+  }),
+);
 
 /**
- * Helper to get current auth state
+ * Helper to set auth state.
  */
-export const getAuth = Signal.peek(authSignal);
+export const setAuth = (user: Option.Option<AuthUser>): Effect.Effect<void, never, AuthStore> =>
+  Effect.service(AuthStore).pipe(Effect.flatMap((store) => store.setAuth(user)));
+
+/**
+ * Helper to get current auth state.
+ */
+export const getAuth: Effect.Effect<Option.Option<AuthUser>, never, AuthStore> = Effect.service(
+  AuthStore,
+).pipe(Effect.flatMap((store) => store.getAuth));
 
 /**
  * Route middleware - checks if user is authenticated.
  * Redirects to /login if not authenticated.
  */
 export const requireAuth = Effect.gen(function* () {
-  const user = yield* Signal.peek(authSignal);
+  const user = yield* getAuth;
 
   if (Option.isNone(user)) {
     return yield* Router.routeRedirect("/login");

--- a/apps/examples/app/services/dashboard.ts
+++ b/apps/examples/app/services/dashboard.ts
@@ -1,18 +1,77 @@
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import * as Context from "effect/Context";
+import { Signal } from "trygg";
+
+export type DashboardThemeMode = "light" | "dark";
+
+export interface DashboardThemeTokens {
+  readonly name: string;
+  readonly primary: string;
+  readonly secondary: string;
+  readonly background: string;
+  readonly cardBackground: string;
+  readonly text: string;
+  readonly textMuted: string;
+}
+
+const lightTheme: DashboardThemeTokens = {
+  name: "Light",
+  primary: "#0066cc",
+  secondary: "#6c757d",
+  background: "#f8f9fa",
+  cardBackground: "#ffffff",
+  text: "#212529",
+  textMuted: "#6c757d",
+};
+
+const darkTheme: DashboardThemeTokens = {
+  name: "Dark",
+  primary: "#4da6ff",
+  secondary: "#adb5bd",
+  background: "#1a1a2e",
+  cardBackground: "#16213e",
+  text: "#e9ecef",
+  textMuted: "#adb5bd",
+};
+
+const themeForMode = (mode: DashboardThemeMode): DashboardThemeTokens =>
+  mode === "dark" ? darkTheme : lightTheme;
+
+const switchLabelForMode = (mode: DashboardThemeMode): string =>
+  `Switch to ${mode === "dark" ? "Light" : "Dark"}`;
 
 export class DashboardTheme extends Context.Service<
   DashboardTheme,
   {
-    readonly name: string;
-    readonly primary: string;
-    readonly secondary: string;
-    readonly background: string;
-    readonly cardBackground: string;
-    readonly text: string;
-    readonly textMuted: string;
+    readonly mode: Signal.Signal<DashboardThemeMode>;
+    readonly tokens: Signal.Signal<DashboardThemeTokens>;
+    readonly switchLabel: Signal.Signal<string>;
+    readonly toggle: () => Effect.Effect<void>;
   }
 >()("DashboardTheme") {}
+
+export const DashboardThemeLive = Layer.effect(
+  DashboardTheme,
+  Effect.gen(function* () {
+    const mode = yield* Signal.make<DashboardThemeMode>("light");
+    const tokens = yield* Signal.make<DashboardThemeTokens>(themeForMode("light"));
+    const switchLabel = yield* Signal.make(switchLabelForMode("light"));
+
+    return {
+      mode,
+      tokens,
+      switchLabel,
+      toggle: () =>
+        Effect.gen(function* () {
+          const current = yield* Signal.peek(mode);
+          const next: DashboardThemeMode = current === "dark" ? "light" : "dark";
+          yield* Signal.set(mode, next);
+          yield* Signal.set(tokens, themeForMode(next));
+          yield* Signal.set(switchLabel, switchLabelForMode(next));
+        }),
+    };
+  }),
+);
 
 export class Analytics extends Context.Service<
   Analytics,

--- a/apps/examples/app/services/theme.ts
+++ b/apps/examples/app/services/theme.ts
@@ -30,14 +30,6 @@ const darkTheme: ThemeTokens = {
 
 const themeForMode = (mode: ThemeMode): ThemeTokens => (mode === "light" ? lightTheme : darkTheme);
 
-// Store signals are module-lifetime on purpose. Until provider Layer.effect
-// lifetimes are cached across ordinary rerenders, stateful stores should use
-// Signal.makeSync + Layer.succeed rather than rebuilding signals in Layer.effect.
-const mode = Signal.makeSync<ThemeMode>("light");
-const tokens = Signal.makeSync<ThemeTokens>(themeForMode("light"));
-const themeName = Signal.makeSync("Light Theme");
-const switchLabel = Signal.makeSync("Switch to Dark Theme");
-
 export class ThemeStore extends Context.Service<
   ThemeStore,
   {
@@ -49,19 +41,29 @@ export class ThemeStore extends Context.Service<
   }
 >()("examples/ThemeStore") {}
 
-export const ThemeStoreLive = Layer.succeed(ThemeStore, {
-  mode,
-  tokens,
-  themeName,
-  switchLabel,
-  toggle: () =>
-    Effect.gen(function* () {
-      const current = yield* Signal.peek(mode);
-      const next: ThemeMode = current === "light" ? "dark" : "light";
-      const nextTokens = themeForMode(next);
-      yield* Signal.set(mode, next);
-      yield* Signal.set(tokens, nextTokens);
-      yield* Signal.set(themeName, `${nextTokens.name} Theme`);
-      yield* Signal.set(switchLabel, `Switch to ${next === "dark" ? "Light" : "Dark"} Theme`);
-    }),
-});
+export const ThemeStoreLive = Layer.effect(
+  ThemeStore,
+  Effect.gen(function* () {
+    const mode = yield* Signal.make<ThemeMode>("light");
+    const tokens = yield* Signal.make<ThemeTokens>(themeForMode("light"));
+    const themeName = yield* Signal.make("Light Theme");
+    const switchLabel = yield* Signal.make("Switch to Dark Theme");
+
+    return {
+      mode,
+      tokens,
+      themeName,
+      switchLabel,
+      toggle: () =>
+        Effect.gen(function* () {
+          const current = yield* Signal.peek(mode);
+          const next: ThemeMode = current === "light" ? "dark" : "light";
+          const nextTokens = themeForMode(next);
+          yield* Signal.set(mode, next);
+          yield* Signal.set(tokens, nextTokens);
+          yield* Signal.set(themeName, `${nextTokens.name} Theme`);
+          yield* Signal.set(switchLabel, `Switch to ${next === "dark" ? "Light" : "Dark"} Theme`);
+        }),
+    };
+  }),
+);

--- a/packages/cli/templates/incident/app/pages/incident-detail.tsx
+++ b/packages/cli/templates/incident/app/pages/incident-detail.tsx
@@ -186,7 +186,7 @@ export default Component.gen(function* () {
       const retry =
         error instanceof IncidentNotFound
           ? undefined
-          : () => Resource.refresh(incidentResource({ id: numericId }));
+          : () => Resource.refresh(incidentResource({ id: numericId })).pipe(Effect.orDie);
 
       return (
         <>

--- a/packages/cli/templates/incident/app/pages/incidents.tsx
+++ b/packages/cli/templates/incident/app/pages/incidents.tsx
@@ -73,7 +73,10 @@ export default Component.gen(function* () {
       </div>
     )),
     Resource.on("Failure", ({ error }) => (
-      <ErrorView error={error} onRetry={() => Resource.refresh(incidentsResource)} />
+      <ErrorView
+        error={error}
+        onRetry={() => Resource.refresh(incidentsResource).pipe(Effect.orDie)}
+      />
     )),
     Resource.exhaustive,
   );

--- a/packages/cli/templates/incident/app/services/theme.ts
+++ b/packages/cli/templates/incident/app/services/theme.ts
@@ -129,9 +129,9 @@ const make = (fallback: ThemeMode): Layer.Layer<AppTheme> =>
     AppTheme,
     Effect.gen(function* () {
       const initialPreference = yield* readStoredPreference;
-      const preference = yield* Signal.make<ThemePreference>(initialPreference);
+      const preference = yield* Signal.make<ThemePreference>(initialPreference).pipe(Effect.orDie);
       const initialMode = yield* resolveMode(initialPreference, fallback);
-      const mode = yield* Signal.make<ThemeMode>(initialMode);
+      const mode = yield* Signal.make<ThemeMode>(initialMode).pipe(Effect.orDie);
 
       const setPreference = (next: ThemePreference): Effect.Effect<void> =>
         Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- Migrates examples and the incident template away from module-lifetime/sync signal state to scoped stores built with `Signal.make` inside provided layers/components.
- Moves example auth/theme/dashboard state behind lifecycle-provided services.
- Updates example/template service signatures so ordinary signal reads/writes no longer mention `SignalDisposedError`.
- Removes unnecessary `Effect.orDie` wrappers around ordinary `Signal.peek`/`Signal.set` operations in template UI handlers.

## DX impact

- Examples now teach the intended Effect-native model: put stateful app stores in `Layer.effect`, provide them at stable component boundaries, and read/update signals without disposal errors in every callback type.
- Template code stays approachable for app authors while still relying on scoped signal ownership under the hood.

## Acceptance criteria

- [x] Examples no longer require removed sync signal APIs.
- [x] Example services expose clean callback signatures for ordinary signal operations.
- [x] Incident template typechecks against lifecycle-aware signal/resource APIs.
- [x] Interactive example state is owned by scoped services instead of module-lifetime globals.

## Weird spots/spots needing attention

- Some template construction/resource retry effects still use explicit failure handling at callback boundaries; those are not disposed-access cleanup wrappers.
- The examples app has separate generated `.trygg`/CSS typecheck noise when invoked outside its normal build path; repo validation covers the supported template/app checks.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. **#210** 👈 current
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->