### PR TITLE
chore(www): migrate docs state to scoped signals

### DIFF
--- a/apps/www/app/__contracts__/docs-layout-persists-across-topic-navigation.contract.tsx
+++ b/apps/www/app/__contracts__/docs-layout-persists-across-topic-navigation.contract.tsx
@@ -147,7 +147,7 @@ const DocsLikeLayout = Component.gen(function* () {
         const observation = yield* observeLayout("layout-cleanup", observedContainer);
         yield* emitObservation(observation);
       }
-    }),
+    }).pipe(Effect.ignore),
   );
 
   return (

--- a/apps/www/app/__contracts__/docs-navigation-no-blank-swap.contract.tsx
+++ b/apps/www/app/__contracts__/docs-navigation-no-blank-swap.contract.tsx
@@ -9,7 +9,8 @@
  *
  * @internal
  */
-import { Effect, SubscriptionRef } from "effect";
+import { Effect, Layer, SubscriptionRef } from "effect";
+import * as Context from "effect/Context";
 import { Component, Signal } from "trygg";
 import { click, render, waitFor } from "trygg/testing";
 import * as Router from "trygg/router";
@@ -91,7 +92,22 @@ export const contract = {
   ],
 } as const;
 
-const headings = Signal.makeSync<ReadonlyArray<string>>([]);
+interface ContractStateService {
+  readonly headings: Signal.Signal<ReadonlyArray<string>>;
+}
+
+class ContractState extends Context.Service<ContractState, ContractStateService>()(
+  "www/DocsNavigationNoBlankSwapState",
+) {}
+
+const ContractStateLive = Layer.effect(
+  ContractState,
+  Signal.make<ReadonlyArray<string>>([]).pipe(
+    Effect.orDie,
+    Effect.map((headings): ContractStateService => ({ headings })),
+  ),
+);
+
 const cleanupSnapshots: Array<SwapSnapshot> = [];
 let observedContainer: HTMLElement | null = null;
 
@@ -160,6 +176,7 @@ const recordCleanupSnapshot = (phase: string) =>
 
 const DocsLikeLayout = Component.gen(function* () {
   const route = yield* Router.currentRoute;
+  const { headings } = yield* ContractState;
 
   if (route.path === "/docs/signals") {
     yield* Effect.addFinalizer(() => recordCleanupSnapshot("old-signals-layout-cleanup"));
@@ -201,6 +218,7 @@ const DocsLikeLayout = Component.gen(function* () {
 });
 
 const SignalsPage = Component.gen(function* () {
+  const { headings } = yield* ContractState;
   yield* Signal.set(headings, ["When to use", "Behavior", "Related exports"]);
   return (
     <article data-testid="signals-article">
@@ -211,6 +229,7 @@ const SignalsPage = Component.gen(function* () {
 });
 
 const ResourcesPage = Component.gen(function* () {
+  const { headings } = yield* ContractState;
   yield* Signal.set(headings, ["When to use", "Behavior", "Related exports"]);
   // Keep the replacement render in flight long enough to mirror the real docs
   // page, where markdown/code rendering is expensive. The invariant is about
@@ -252,6 +271,7 @@ const runScenario = Effect.scoped(
   Effect.gen(function* () {
     cleanupSnapshots.length = 0;
     observedContainer = null;
+    const { headings } = yield* ContractState;
     yield* Signal.set(headings, []);
 
     const result = yield* ContractTrace.withAction(
@@ -365,7 +385,7 @@ const runScenario = Effect.scoped(
     }
 
     return [] satisfies ReadonlyArray<ContractViolation>;
-  }).pipe(Effect.provide(Router.testLayer("/docs/signals"))),
+  }).pipe(Effect.provide(Layer.merge(Router.testLayer("/docs/signals"), ContractStateLive))),
 );
 
 const normalizeViolations = (

--- a/apps/www/app/__contracts__/docs-route-settles-to-latest.contract.tsx
+++ b/apps/www/app/__contracts__/docs-route-settles-to-latest.contract.tsx
@@ -9,7 +9,8 @@
  *
  * @internal
  */
-import { Effect, SubscriptionRef } from "effect";
+import { Effect, Layer, SubscriptionRef } from "effect";
+import * as Context from "effect/Context";
 import { Component, Signal } from "trygg";
 import { click, render, waitFor } from "trygg/testing";
 import * as Router from "trygg/router";
@@ -81,8 +82,24 @@ export const contract = {
   ],
 } as const;
 
-const headings = Signal.makeSync<ReadonlyArray<string>>([]);
-const rerenderTick = Signal.makeSync(0);
+interface ContractStateService {
+  readonly headings: Signal.Signal<ReadonlyArray<string>>;
+  readonly rerenderTick: Signal.Signal<number>;
+}
+
+class ContractState extends Context.Service<ContractState, ContractStateService>()(
+  "www/DocsRouteSettlesState",
+) {}
+
+const ContractStateLive = Layer.effect(
+  ContractState,
+  Effect.gen(function* () {
+    const headings = yield* Signal.make<ReadonlyArray<string>>([]).pipe(Effect.orDie);
+    const rerenderTick = yield* Signal.make(0).pipe(Effect.orDie);
+    return { headings, rerenderTick } satisfies ContractStateService;
+  }),
+);
+
 const staleRouteRenders: Array<string> = [];
 const routeRenderLog: Array<string> = [];
 
@@ -125,6 +142,7 @@ const DocsLikeLayout = Component.gen(function* () {
   // appears when this old layout re-renders with its previous Outlet child after
   // router.current has already moved to the next route.
   const route = yield* Router.currentRoute;
+  const { headings } = yield* ContractState;
 
   return (
     <section data-testid="docs-layout" data-path={route.path}>
@@ -170,6 +188,7 @@ const GettingStartedPage = Component.gen(function* () {
   // Subscribes the old route to a local route-state change. The contract then
   // bumps this while the next route is rendering, reproducing the debug trace's
   // stale getting-started work after router.current has moved on.
+  const { headings, rerenderTick } = yield* ContractState;
   yield* Signal.get(rerenderTick);
   yield* recordRouteRender("getting-started", "/docs/getting-started");
   yield* Signal.set(headings, ["Prerequisites", "Create a project", "Install"]);
@@ -182,6 +201,7 @@ const GettingStartedPage = Component.gen(function* () {
 });
 
 const ComponentsPage = Component.gen(function* () {
+  const { headings } = yield* ContractState;
   yield* recordRouteRender("components", "/docs/components");
   // The real docs topic route updates docsHeadings before async article work
   // such as syntax highlighting completes. Keep the new route render in flight
@@ -250,6 +270,7 @@ const runScenario = Effect.scoped(
   Effect.gen(function* () {
     staleRouteRenders.length = 0;
     routeRenderLog.length = 0;
+    const { headings, rerenderTick } = yield* ContractState;
     yield* Signal.set(headings, []);
     yield* Signal.set(rerenderTick, 0);
 
@@ -383,7 +404,9 @@ const runScenario = Effect.scoped(
     }
 
     return [] satisfies ReadonlyArray<ContractViolation>;
-  }).pipe(Effect.provide(Router.testLayer("/docs/getting-started"))),
+  }).pipe(
+    Effect.provide(Layer.merge(Router.testLayer("/docs/getting-started"), ContractStateLive)),
+  ),
 );
 
 const normalizeViolations = (

--- a/apps/www/app/__contracts__/home-workbench-types.contract.tsx
+++ b/apps/www/app/__contracts__/home-workbench-types.contract.tsx
@@ -113,10 +113,9 @@ type _UserListProps = AssertTrue<
   >
 >;
 
-// Probe: does UserList's error slot collapse to `never` after Resource.exhaustive
-// covers all three states (Pending, Success, Failure)? Resource.exhaustive
-// returns `Effect.Effect<ElementType, never, Scope.Scope | R>`, so the
-// component should carry E = never.
+// Probe: Resource.exhaustive covers all three resource states (Pending,
+// Success, Failure). Disposed signal access is reported as a diagnostic defect,
+// not as a typed component error channel.
 type _UserListErrorIsNever = AssertTrue<
   Types.Equals<
     typeof UserList extends Component.Type<infer _P, infer E, infer _R> ? E : never,

--- a/apps/www/app/components/docs-layout.test.tsx
+++ b/apps/www/app/components/docs-layout.test.tsx
@@ -7,11 +7,18 @@ import * as Router from "trygg/router";
 
 import { DocsLayout } from "./docs-layout";
 import { DocsSidebar } from "./docs-sidebar";
+import { DocsHeadingsLive } from "../content/headings";
 import { Footer } from "./footer";
 
-const docsGettingStartedLayer = Layer.merge(testLayer, Router.testLayer("/docs/getting-started"));
-const docsElementsLayer = Layer.merge(testLayer, Router.testLayer("/docs/elements"));
-const homeLayer = Layer.merge(testLayer, Router.testLayer("/"));
+const docsGettingStartedLayer = Layer.merge(
+  Layer.merge(testLayer, Router.testLayer("/docs/getting-started")),
+  DocsHeadingsLive,
+);
+const docsElementsLayer = Layer.merge(
+  Layer.merge(testLayer, Router.testLayer("/docs/elements")),
+  DocsHeadingsLive,
+);
+const homeLayer = Layer.merge(Layer.merge(testLayer, Router.testLayer("/")), DocsHeadingsLive);
 
 describe("Docs chrome", () => {
   layer(docsGettingStartedLayer)("/docs/getting-started", (it) => {

--- a/apps/www/app/components/docs-layout.tsx
+++ b/apps/www/app/components/docs-layout.tsx
@@ -6,7 +6,7 @@ import { DocsSidebar } from "./docs-sidebar";
 import { Footer } from "./footer";
 import { Header } from "./header";
 import { sidebarGroups } from "../content/sidebar";
-import { docsHeadings } from "../content/headings";
+import { DocsHeadings } from "../content/headings";
 import { currentRouteSnapshot } from "../lib/router-snapshot";
 
 const sidebarLinks = sidebarGroups.flatMap((group) => group.links);
@@ -160,10 +160,12 @@ const DocsPrevNext = Component.gen(function* () {
 });
 
 export const DocsLayout = Component.gen(function* () {
+  const headings = yield* DocsHeadings;
   const drawerOpen = yield* Signal.make(false);
   const drawerClass = yield* Signal.derive(drawerOpen, (open): string =>
     open ? "docs-drawer docs-drawer--open" : "docs-drawer",
   );
+  const drawerHidden = yield* Signal.derive(drawerOpen, (open) => !open);
 
   const openDrawer = () => Signal.set(drawerOpen, true);
   const closeDrawer = () => Signal.set(drawerOpen, false);
@@ -200,7 +202,7 @@ export const DocsLayout = Component.gen(function* () {
           <DocsSidebar />
         </aside>
 
-        <div className={drawerClass} aria-hidden={Signal.derive(drawerOpen, (open) => !open)}>
+        <div className={drawerClass} aria-hidden={drawerHidden}>
           <button
             type="button"
             className="docs-drawer__backdrop"
@@ -221,7 +223,7 @@ export const DocsLayout = Component.gen(function* () {
           <p className="docs-rail__title">On this page</p>
           <ul className="docs-rail__links" role="list">
             {Signal.each(
-              docsHeadings,
+              headings.entries,
               (heading) =>
                 Effect.succeed(
                   <li>

--- a/apps/www/app/components/search-dialog.tsx
+++ b/apps/www/app/components/search-dialog.tsx
@@ -61,7 +61,8 @@ export const SearchDialog = Component.gen(function* (Props: ComponentProps<Searc
 
   const handleKeyDown = (e: Event): Effect.Effect<void> =>
     Effect.gen(function* () {
-      const ke = e as KeyboardEvent;
+      if (!(e instanceof KeyboardEvent)) return;
+      const ke = e;
       if (ke.key === "Escape") {
         yield* close;
         return;
@@ -87,7 +88,9 @@ export const SearchDialog = Component.gen(function* (Props: ComponentProps<Searc
 
   const handleInput = (e: Event): Effect.Effect<void> =>
     Effect.gen(function* () {
-      yield* Signal.set(query, (e.target as HTMLInputElement).value);
+      const target = e.target;
+      if (!(target instanceof HTMLInputElement)) return;
+      yield* Signal.set(query, target.value);
       yield* Signal.set(activeIndex, 0);
     });
 

--- a/apps/www/app/content/headings.ts
+++ b/apps/www/app/content/headings.ts
@@ -1,3 +1,5 @@
+import { Effect, Layer } from "effect";
+import * as Context from "effect/Context";
 import { Signal } from "trygg";
 
 export interface HeadingEntry {
@@ -6,5 +8,29 @@ export interface HeadingEntry {
   readonly level: 2 | 3;
 }
 
-// Shared signal for docs page headings (used by right rail "On this page")
-export const docsHeadings = Signal.makeSync<ReadonlyArray<HeadingEntry>>([]);
+export interface DocsHeadingsService {
+  readonly entries: Signal.Signal<ReadonlyArray<HeadingEntry>>;
+  readonly set: (entries: ReadonlyArray<HeadingEntry>) => Effect.Effect<void>;
+}
+
+export class DocsHeadings extends Context.Service<DocsHeadings, DocsHeadingsService>()(
+  "www/DocsHeadings",
+) {}
+
+export const DocsHeadingsLive = Layer.effect(
+  DocsHeadings,
+  Signal.make<ReadonlyArray<HeadingEntry>>([]).pipe(
+    Effect.orDie,
+    Effect.map(
+      (entries): DocsHeadingsService => ({
+        entries,
+        set: (nextEntries) => Signal.set(entries, nextEntries),
+      }),
+    ),
+  ),
+);
+
+export const setDocsHeadings = (
+  entries: ReadonlyArray<HeadingEntry>,
+): Effect.Effect<void, never, DocsHeadings> =>
+  Effect.service(DocsHeadings).pipe(Effect.flatMap((headings) => headings.set(entries)));

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -9,6 +9,7 @@ import "../styles.css";
 import { Component } from "trygg";
 import * as Router from "trygg/router";
 
+import { DocsHeadingsLive } from "./content/headings";
 import { themeColor, themeInitScript } from "./lib/theme";
 
 const seo = {
@@ -34,7 +35,7 @@ const jsonLd = {
   programmingLanguage: "TypeScript",
 };
 
-export default Component.gen(function* () {
+const AppLayout = Component.gen(function* () {
   return (
     <html lang="en" data-theme="light">
       <head>
@@ -97,3 +98,5 @@ export default Component.gen(function* () {
     </html>
   );
 });
+
+export default AppLayout.pipe(Component.provide(DocsHeadingsLive));

--- a/apps/www/app/pages/docs/page.tsx
+++ b/apps/www/app/pages/docs/page.tsx
@@ -1,6 +1,6 @@
-import { Component, Signal } from "trygg";
+import { Component } from "trygg";
 import * as Router from "trygg/router";
-import { docsHeadings } from "../../content/headings";
+import { setDocsHeadings } from "../../content/headings";
 import { sidebarGroups } from "../../content/sidebar";
 
 const quickPath = [
@@ -65,7 +65,7 @@ const sectionSummaries: ReadonlyArray<{
 const sectionCounts = sidebarGroups.map((group) => group.links.length);
 
 export default Component.gen(function* () {
-  yield* Signal.set(docsHeadings, []);
+  yield* setDocsHeadings([]);
 
   return (
     <>

--- a/apps/www/app/pages/docs/topic.tsx
+++ b/apps/www/app/pages/docs/topic.tsx
@@ -1,9 +1,9 @@
-import { Component, Signal } from "trygg";
+import { Component } from "trygg";
 import * as Router from "trygg/router";
 
 import { DocsArticle, extractDocsHeadings } from "../../components/docs-article";
 import { docsContent } from "../../content/docs-content";
-import { docsHeadings, type HeadingEntry } from "../../content/headings";
+import { setDocsHeadings, type HeadingEntry } from "../../content/headings";
 import { sidebarGroups } from "../../content/sidebar";
 import { currentRouteSnapshot } from "../../lib/router-snapshot";
 
@@ -24,7 +24,7 @@ export default Component.gen(function* () {
   const link = sidebarLinks.find((item) => item.href === path);
   const content = docsContent[path];
 
-  yield* Signal.set(docsHeadings, content ? extractDocsHeadings(content) : placeholderHeadings);
+  yield* setDocsHeadings(content ? extractDocsHeadings(content) : placeholderHeadings);
 
   if (content) {
     const docTitle = link?.label ?? "Docs topic";

--- a/apps/www/app/pages/getting-started.test.tsx
+++ b/apps/www/app/pages/getting-started.test.tsx
@@ -1,13 +1,16 @@
 // @vitest-environment happy-dom
 
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { describe, expect, it, vi } from "vitest";
 import { click, renderElement, testLayer, waitFor } from "trygg/testing";
 
 import GettingStartedPage from "./getting-started";
+import { DocsHeadingsLive } from "../content/headings";
 
 const renderGettingStarted = () =>
-  renderElement(<GettingStartedPage />).pipe(Effect.provide(testLayer));
+  renderElement(<GettingStartedPage />).pipe(
+    Effect.provide(Layer.merge(testLayer, DocsHeadingsLive)),
+  );
 
 describe("GettingStartedPage", () => {
   it("renders prerequisites, create project, and install instructions", async () => {

--- a/apps/www/app/pages/getting-started.tsx
+++ b/apps/www/app/pages/getting-started.tsx
@@ -8,7 +8,7 @@ import {
   type CommandSection,
   type PackageManager,
 } from "../content/getting-started";
-import { docsHeadings } from "../content/headings";
+import { setDocsHeadings } from "../content/headings";
 import gettingStartedSource from "../examples/getting-started.tsx?raw";
 
 const SectionShell = Component.gen(function* (
@@ -121,7 +121,7 @@ const gettingStartedHeadings = [
 ];
 
 export default Component.gen(function* () {
-  yield* Signal.set(docsHeadings, gettingStartedHeadings);
+  yield* setDocsHeadings(gettingStartedHeadings);
 
   const selectedPackageManager = yield* Signal.make<PackageManager>("bun");
   const exampleLines = yield* Effect.promise(() => highlightCode(gettingStartedSource, "tsx"));

--- a/apps/www/app/routes.test.tsx
+++ b/apps/www/app/routes.test.tsx
@@ -1,10 +1,11 @@
 /* @vitest-environment happy-dom */
 
 import { describe, expect, it } from "vitest";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { render, waitFor } from "trygg/testing";
 import * as Router from "trygg/router";
 
+import { DocsHeadingsLive } from "./content/headings";
 import { sidebarGroups } from "./content/sidebar";
 import { routes } from "./routes";
 
@@ -16,7 +17,7 @@ const renderRoute = (path: string) =>
     const current = yield* Router.currentRoute;
 
     return { current, result };
-  }).pipe(Effect.provide(Router.testLayer(path)), Effect.scoped);
+  }).pipe(Effect.provide(Layer.merge(Router.testLayer(path), DocsHeadingsLive)), Effect.scoped);
 
 describe("docs routes", () => {
   it("renders the docs landing at /docs", async () => {
@@ -77,7 +78,9 @@ describe("docs routes", () => {
             }
             return true;
           });
-        }).pipe(Effect.provide(Router.testLayer("/docs/components"))),
+        }).pipe(
+          Effect.provide(Layer.merge(Router.testLayer("/docs/components"), DocsHeadingsLive)),
+        ),
       ),
     );
   });
@@ -109,7 +112,7 @@ describe("docs routes", () => {
           expect(result.container.querySelectorAll(".docs-layout__sidebar")).toHaveLength(1);
           expect(result.container.querySelectorAll("footer")).toHaveLength(1);
           expect(result.container.textContent).not.toContain("Page not found");
-        }).pipe(Effect.provide(Router.testLayer("/docs/elements"))),
+        }).pipe(Effect.provide(Layer.merge(Router.testLayer("/docs/elements"), DocsHeadingsLive))),
       ),
     );
   });

--- a/apps/www/changelogs/2026-02-08-incident-dashboard-template.md
+++ b/apps/www/changelogs/2026-02-08-incident-dashboard-template.md
@@ -10,7 +10,7 @@ This canary adds selectable project templates, a full-stack incident dashboard s
 ## Changed
 
 - **Breaking:** Return `Signal<boolean>` from `Router.isActive` instead of a boolean, enabling fine-grained active-link updates without rerendering route components; see the [router service guide](../../../packages/core/src/router/service.docs.md).
-- **Breaking:** Rename `Signal.unsafeMake` to `Signal.makeSync`, clarifying that synchronous signals are for module-lifetime state and service-backed globals; see the [signal guide](../../../packages/core/src/primitives/signal.docs.md).
+- **Breaking:** Move signal creation toward Effect-scoped `Signal.make` state for service-backed globals; see the [signal guide](../../../packages/core/src/primitives/signal.docs.md).
 - **Breaking:** Move testing helper imports from the root `trygg` entrypoint to `trygg/testing`.
 - Forward user `data-*` and `aria-*` attributes from `Link` to the underlying anchor, supporting active-state attributes derived from `Router.isActive`; see the [link guide](../../../packages/core/src/router/link.docs.md).
 - Track schema-decoded route params and query requirements through route builders and error-boundary coverage, surfacing missing route boundaries at typecheck time; see the [route guide](../../../packages/core/src/router/route.docs.md).

--- a/packages/core/src/primitives/signal.ts
+++ b/packages/core/src/primitives/signal.ts
@@ -545,39 +545,6 @@ export const make: <A>(initial: A) => Effect.Effect<Signal<A>, SignalScopeError>
 });
 
 /**
- * Create a module-lifetime signal synchronously.
- *
- * @remarks
- * This compatibility factory intentionally does not register a scope finalizer.
- * Prefer `Signal.make` inside a component, lifecycle-provided layer, or
- * explicitly scoped Effect so signal ownership is observable and deterministic.
- *
- * @example
- * ```tsx
- * const signal = Signal.makeSync("legacy")
- * const value = yield* Signal.peek(signal)
- * ```
- *
- * @deprecated Use scoped `Signal.make` instead.
- * @category Reactivity
- * @public
- * @since 1.0.0
- */
-export const makeSync = <A>(initial: A): Signal<A> => {
-  const ref = Effect.runSync(SubscriptionRef.make(initial));
-  const disposed = Effect.runSync(Ref.make(false));
-  const debugId = Debug.nextSignalId();
-  return {
-    _tag: "Signal",
-    _ref: ref,
-    _listeners: new Set(),
-    _debugId: debugId,
-    _owner: "effect",
-    _disposed: disposed,
-  };
-};
-
-/**
  * Get the current value of a signal.
  *
  * IMPORTANT: Reading a signal with Signal.get() subscribes the current


### PR DESCRIPTION
## Summary

- Replaces the docs site's shared headings global with a scoped `DocsHeadings` service provided by the root layout/tests.
- Updates docs route/page code, contracts, drawer/search handlers, and home workbench snippets to use clean signal operation signatures.
- Removes the temporary `Signal.makeSync` compatibility shim after all stacked app/template migrations are in place.

## DX impact

- The docs app now mirrors the recommended app-store pattern: scoped services instead of module-lifetime signals.
- Docs UI handlers can call `Signal.set`/`Signal.peek` directly without disposal errors leaking into their types.
- The final public API no longer offers the sync global-state escape hatch.

## Acceptance criteria

- [x] No live runtime/docs-site/template references to `Signal.makeSync` remain.
- [x] Docs headings are scoped to the app/layout lifecycle.
- [x] Docs navigation contracts typecheck with clean signal operation error channels.
- [x] `apps/www` typecheck and tests pass after rebuilding core.

## Weird spots/spots needing attention

- Docs contract fixtures still create scoped test signals explicitly; construction remains scoped/typed even though ordinary reads and writes are clean.
- The docs route-settling/no-blank-swap contracts are intentionally detailed because they guard subtle stale-render regressions.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. **#211** 👈 current
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->