### PR TITLE
test(core): cover lifecycle edge contracts

### DIFF
--- a/packages/core/src/internal/unsafe.ts
+++ b/packages/core/src/internal/unsafe.ts
@@ -82,11 +82,10 @@ export const unsafeBuildProviderContext = (
   scope: Scope.Scope,
   parentContext: Context.Context<unknown> | null,
 ): Effect.Effect<Context.Context<unknown>, unknown, unknown> => {
-  const build = Layer.buildWithScope(layer, scope) as Effect.Effect<
-    Context.Context<unknown>,
-    unknown,
-    unknown
-  >;
+  const build = Effect.gen(function* () {
+    const memoMap = yield* Layer.makeMemoMap;
+    return yield* Layer.buildWithMemoMap(layer, memoMap, scope);
+  }) as Effect.Effect<Context.Context<unknown>, unknown, unknown>;
   return parentContext === null ? build : Effect.provide(build, parentContext);
 };
 

--- a/packages/core/src/primitives/__tests__/render-component.test.tsx
+++ b/packages/core/src/primitives/__tests__/render-component.test.tsx
@@ -3,7 +3,8 @@ import { Cause, Effect, Exit, Layer, Scope } from "effect";
 import * as Context from "effect/Context";
 import { TestClock } from "effect/testing";
 import { scoped } from "../../testing/effect-vitest.js";
-import { render } from "../../testing/index.js";
+import * as ContractTrace from "../../contract/trace.js";
+import { click, render } from "../../testing/index.js";
 import * as Component from "../component.js";
 import * as ErrorBoundary from "../error-boundary.js";
 import * as Signal from "../signal.js";
@@ -108,6 +109,193 @@ describe("render-component", () => {
       yield* TestClock.adjust(20);
 
       assert.strictEqual((yield* getByTestId("fallback")).textContent, "fallback");
+    }),
+  );
+
+  scoped("replaces provider scope when component key changes", () =>
+    Effect.gen(function* () {
+      const collector = yield* ContractTrace.createInMemoryCollector("provider-key-change");
+      const selectedKey = yield* Signal.make<"first" | "second">("first");
+      const acquireLog: Array<string> = [];
+      const finalizeLog: Array<string> = [];
+
+      class Label extends Context.Service<Label, { readonly value: string }>()("test/Label") {}
+
+      const LabelLive = Layer.effect(
+        Label,
+        Effect.gen(function* () {
+          acquireLog.push("label");
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              finalizeLog.push("label");
+            }),
+          );
+          return { value: "label" };
+        }),
+      );
+
+      const LabelView = Component.gen(function* () {
+        const label = yield* Label;
+        return <div data-testid="key-label">{label.value}</div>;
+      });
+
+      const ProvidedLabel = LabelView.pipe(Component.provide(LabelLive));
+
+      const Host = Component.gen(function* () {
+        const key = yield* Signal.get(selectedKey);
+        return <ProvidedLabel key={key} />;
+      });
+
+      const { getByTestId } = yield* ContractTrace.withCollector(render(<Host />), collector);
+      assert.strictEqual((yield* getByTestId("key-label")).textContent, "label");
+      assert.deepStrictEqual(acquireLog, ["label"]);
+
+      yield* Signal.set(selectedKey, "second");
+      yield* TestClock.adjust(20);
+
+      assert.strictEqual((yield* getByTestId("key-label")).textContent, "label");
+      const records = yield* collector.snapshot;
+      assert.deepStrictEqual(acquireLog, ["label", "label"]);
+      assert.deepStrictEqual(finalizeLog, ["label"]);
+
+      const replacementReasons = records.flatMap((record) =>
+        record.event.event === "provider.replace" &&
+        typeof record.event.payload?.reason === "string"
+          ? [record.event.payload.reason]
+          : [],
+      );
+      assert.include(replacementReasons, "key-change");
+    }),
+  );
+
+  scoped("replaces provider scope when layer identity changes", () =>
+    Effect.gen(function* () {
+      const collector = yield* ContractTrace.createInMemoryCollector("provider-identity-change");
+      const selected = yield* Signal.make<"first" | "second">("first");
+      const acquireLog: Array<string> = [];
+      const finalizeLog: Array<string> = [];
+
+      class Label extends Context.Service<Label, { readonly value: string }>()("test/Label") {}
+
+      const makeLabelLayer = (value: string) =>
+        Layer.effect(
+          Label,
+          Effect.gen(function* () {
+            acquireLog.push(value);
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => {
+                finalizeLog.push(value);
+              }),
+            );
+            return { value };
+          }),
+        );
+
+      const FirstLive = makeLabelLayer("first");
+      const SecondLive = makeLabelLayer("second");
+
+      const LabelView = Component.gen(function* () {
+        const label = yield* Label;
+        return <div data-testid="identity-label">{label.value}</div>;
+      });
+
+      const FirstLabel = LabelView.pipe(Component.provide(FirstLive));
+      const SecondLabel = LabelView.pipe(Component.provide(SecondLive));
+
+      const Host = Component.gen(function* () {
+        const value = yield* Signal.get(selected);
+        return value === "first" ? <FirstLabel key="stable" /> : <SecondLabel key="stable" />;
+      });
+
+      const { getByTestId } = yield* ContractTrace.withCollector(render(<Host />), collector);
+      assert.strictEqual((yield* getByTestId("identity-label")).textContent, "first");
+      assert.deepStrictEqual(acquireLog, ["first"]);
+
+      yield* Signal.set(selected, "second");
+      yield* TestClock.adjust(20);
+
+      assert.strictEqual((yield* getByTestId("identity-label")).textContent, "second");
+      assert.deepStrictEqual(acquireLog, ["first", "second"]);
+      assert.deepStrictEqual(finalizeLog, ["first"]);
+
+      const records = yield* collector.snapshot;
+      const replacementReasons = records.flatMap((record) =>
+        record.event.event === "provider.replace" &&
+        typeof record.event.payload?.reason === "string"
+          ? [record.event.payload.reason]
+          : [],
+      );
+      assert.include(replacementReasons, "identity-change");
+    }),
+  );
+
+  scoped("routes provider acquisition failure through error boundary and retries on reset", () =>
+    Effect.gen(function* () {
+      const collector = yield* ContractTrace.createInMemoryCollector("provider-failure-retry");
+      const providerShouldFail = yield* Signal.make(true);
+      const retryKey = yield* Signal.make(0);
+      let acquireAttempts = 0;
+
+      class FlakyService extends Context.Service<FlakyService, { readonly label: string }>()(
+        "test/FlakyService",
+      ) {}
+
+      const FlakyLive = Layer.effect(
+        FlakyService,
+        Effect.gen(function* () {
+          acquireAttempts += 1;
+          const shouldFail = yield* Signal.peek(providerShouldFail);
+          if (shouldFail) {
+            return yield* Effect.fail("provider failed");
+          }
+          return { label: "ready" };
+        }),
+      );
+
+      const Risky = Component.gen(function* () {
+        const service = yield* FlakyService;
+        return <div data-testid="provider-ready">{service.label}</div>;
+      }).pipe(Component.provide(FlakyLive));
+
+      const Fallback = Component.gen(function* (
+        Props: Component.ComponentProps<{ readonly cause: Cause.Cause<unknown> }>,
+      ) {
+        yield* Props;
+        return (
+          <button
+            data-testid="provider-retry"
+            onClick={() =>
+              Effect.gen(function* () {
+                yield* Signal.set(providerShouldFail, false);
+                yield* Signal.update(retryKey, (value) => value + 1);
+              })
+            }
+          >
+            Retry provider
+          </button>
+        );
+      });
+
+      const SafeRisky = yield* ErrorBoundary.catch(Risky).pipe(ErrorBoundary.catchAll(Fallback));
+
+      const Host = Component.gen(function* () {
+        const key = yield* Signal.get(retryKey);
+        return <SafeRisky key={key} />;
+      });
+
+      const { getByTestId } = yield* ContractTrace.withCollector(render(<Host />), collector);
+      assert.strictEqual((yield* getByTestId("provider-retry")).textContent, "Retry provider");
+      assert.strictEqual(acquireAttempts, 1);
+
+      yield* click(yield* getByTestId("provider-retry"));
+      yield* TestClock.adjust(20);
+
+      assert.strictEqual((yield* getByTestId("provider-ready")).textContent, "ready");
+      assert.strictEqual(acquireAttempts, 2);
+
+      const events = (yield* collector.snapshot).map((record) => record.event.event);
+      assert.strictEqual(events.filter((event) => event === "provider.failure").length, 1);
+      assert.strictEqual(events.filter((event) => event === "provider.acquire").length, 1);
     }),
   );
 

--- a/packages/core/src/primitives/__tests__/signal.test.ts
+++ b/packages/core/src/primitives/__tests__/signal.test.ts
@@ -21,13 +21,14 @@
  */
 import { assert, describe, it } from "@effect/vitest";
 import { scoped } from "../../testing/effect-vitest.js";
-import { Cause, Data, Deferred, Effect, Exit, Fiber, Layer, Ref, Result, Scope } from "effect";
+import { Cause, Data, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Result, Scope } from "effect";
 import * as Context from "effect/Context";
 import { TestClock } from "effect/testing";
 import * as Signal from "../signal.js";
 // Import element.js to initialize _signalElementImpl/_textElementImpl
 import { Element, text } from "../element.js";
 import * as Component from "../component.js";
+import * as ContractTrace from "../../contract/trace.js";
 import { unsafeEraseR } from "../../internal/unsafe.js";
 import { render } from "../../testing/index.js";
 
@@ -154,6 +155,29 @@ describe("Signal.make ownership", () => {
     }),
   );
 
+  it.effect("should fail signal creation without an owning scope", () =>
+    Effect.gen(function* () {
+      // Test: should reject orphaned signal state when no Effect scope exists.
+      // Scope: verifies Signal.make cannot silently create module-lifetime state.
+      // Assertion: creation fails with SignalScopeError and the make operation.
+      const exit = yield* unsafeEraseR(
+        Signal.make("orphan").pipe(Effect.updateContext(Context.omit(Scope.Scope)), Effect.exit),
+      );
+
+      assert.isTrue(Exit.isFailure(exit));
+      if (Exit.isFailure(exit)) {
+        const error = Cause.findErrorOption(exit.cause);
+        assert.isTrue(Option.isSome(error));
+        if (Option.isSome(error)) {
+          assert.instanceOf(error.value, Signal.SignalScopeError);
+          if (error.value instanceof Signal.SignalScopeError) {
+            assert.strictEqual(error.value.operation, "make");
+          }
+        }
+      }
+    }),
+  );
+
   scoped("should fail disposed signal access after owner scope closes", () =>
     Effect.gen(function* () {
       // Test: should fail user reads after signal owner disposal.
@@ -172,6 +196,28 @@ describe("Signal.make ownership", () => {
           assert.instanceOf(defect.success, Signal.SignalDisposedError);
         }
       }
+    }),
+  );
+
+  scoped("should trace signal disposal and disposed access", () =>
+    Effect.gen(function* () {
+      // Test: should emit lifecycle trace records for create, dispose, and stale access.
+      // Scope: verifies observability ICD events are produced, not just the error value.
+      // Assertion: ContractTrace records the signal event family in order for one signal.
+      const collector = yield* ContractTrace.createInMemoryCollector("signal-disposal");
+
+      yield* ContractTrace.withCollector(
+        Effect.gen(function* () {
+          const scope = yield* Scope.make();
+          const signal = yield* Signal.make("owned").pipe(Scope.provide(scope));
+          yield* Scope.close(scope, Exit.void);
+          yield* Signal.peek(signal).pipe(Effect.exit);
+        }),
+        collector,
+      );
+
+      const events = (yield* collector.snapshot).map((record) => record.event.event);
+      assert.deepStrictEqual(events, ["signal.create", "signal.dispose", "signal.disposed_access"]);
     }),
   );
 });


### PR DESCRIPTION
## Summary

- Fixes provider-boundary layer reuse by building each provided component boundary with a fresh Effect layer memo map.
- Adds regression coverage for provider replacement on component key changes and layer identity changes.
- Adds acquisition-failure coverage through error boundaries, including retry after boundary reset.
- Adds signal lifecycle edge coverage for ownerless `Signal.make` failures and create/dispose/disposed-access diagnostics.

## DX impact

- Provider replacement now reacquires services and finalizes old scoped state predictably.
- Ownerless `Signal.make` remains a typed construction/scope error, while disposed signal access is verified as a loud diagnostic defect rather than a public application error.

## Acceptance criteria

- [x] Provider memoization is isolated per mounted provider boundary.
- [x] Key/identity replacement reacquires services and finalizes old scopes.
- [x] Layer acquisition failures reach error boundaries and can recover after reset.
- [x] Signal lifecycle edge cases have regression coverage.

## Weird spots/spots needing attention

- The ownerless signal test deliberately removes `Scope.Scope` from context to prove the construction failure path.
- Disposed access assertions inspect defects/cause data because `SignalDisposedError` is intentionally no longer a typed operation error.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. **#224** 👈 current
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->