### PR TITLE
docs: align lifecycle provision guidance

### DIFF
--- a/apps/examples/app/components/dashboard/action-button.tsx
+++ b/apps/examples/app/components/dashboard/action-button.tsx
@@ -1,17 +1,18 @@
 import { Effect } from "effect";
-import { Component, type ComponentProps } from "trygg";
+import { Component, Signal, type ComponentProps } from "trygg";
 import { DashboardTheme, Analytics } from "../../services/dashboard";
 
 export const ActionButton = Component.gen(function* (
   Props: ComponentProps<{
     label: string;
     variant: "primary" | "secondary";
-    onClick: () => Effect.Effect<void>;
+    onClick: () => Effect.Effect<void, unknown, unknown>;
   }>,
 ) {
   const { label, variant, onClick } = yield* Props;
-  const theme = yield* DashboardTheme;
+  const themeStore = yield* DashboardTheme;
   const analytics = yield* Analytics;
+  const theme = yield* Signal.get(themeStore.tokens);
 
   const handleClick = () =>
     Effect.gen(function* () {

--- a/apps/examples/app/components/dashboard/activity-item.tsx
+++ b/apps/examples/app/components/dashboard/activity-item.tsx
@@ -1,4 +1,4 @@
-import { Component, type ComponentProps } from "trygg";
+import { Component, Signal, type ComponentProps } from "trygg";
 import { DashboardTheme, Analytics } from "../../services/dashboard";
 
 export const ActivityItem = Component.gen(function* (
@@ -8,8 +8,9 @@ export const ActivityItem = Component.gen(function* (
   }>,
 ) {
   const { text, time } = yield* Props;
-  const theme = yield* DashboardTheme;
+  const themeStore = yield* DashboardTheme;
   const analytics = yield* Analytics;
+  const theme = yield* Signal.get(themeStore.tokens);
 
   const onClick = () => analytics.track("activity_clicked", { text });
 

--- a/apps/examples/app/components/dashboard/header.tsx
+++ b/apps/examples/app/components/dashboard/header.tsx
@@ -1,4 +1,4 @@
-import { Component, type ComponentProps } from "trygg";
+import { Component, Signal, type ComponentProps } from "trygg";
 import { DashboardTheme, Logger } from "../../services/dashboard";
 
 export const Header = Component.gen(function* (
@@ -7,8 +7,9 @@ export const Header = Component.gen(function* (
   }>,
 ) {
   const { userName } = yield* Props;
-  const theme = yield* DashboardTheme;
+  const themeStore = yield* DashboardTheme;
   const logger = yield* Logger;
+  const theme = yield* Signal.get(themeStore.tokens);
 
   yield* logger.info(`Header rendered for ${userName}`);
 

--- a/apps/examples/app/components/dashboard/section-title.tsx
+++ b/apps/examples/app/components/dashboard/section-title.tsx
@@ -1,9 +1,10 @@
-import { Component, type ComponentProps } from "trygg";
+import { Component, Signal, type ComponentProps } from "trygg";
 import { DashboardTheme } from "../../services/dashboard";
 
 export const SectionTitle = Component.gen(function* (Props: ComponentProps<{ title: string }>) {
   const { title } = yield* Props;
-  const theme = yield* DashboardTheme;
+  const themeStore = yield* DashboardTheme;
+  const theme = yield* Signal.get(themeStore.tokens);
 
   return (
     <h2 className="mb-4" style={{ color: theme.text }}>

--- a/apps/examples/app/components/dashboard/stat-card.tsx
+++ b/apps/examples/app/components/dashboard/stat-card.tsx
@@ -1,4 +1,4 @@
-import { Component, type ComponentProps } from "trygg";
+import { Component, Signal, type ComponentProps } from "trygg";
 import { DashboardTheme } from "../../services/dashboard";
 
 export const StatCard = Component.gen(function* (
@@ -9,7 +9,8 @@ export const StatCard = Component.gen(function* (
   }>,
 ) {
   const { title, value, change } = yield* Props;
-  const theme = yield* DashboardTheme;
+  const themeStore = yield* DashboardTheme;
+  const theme = yield* Signal.get(themeStore.tokens);
 
   return (
     <div className="p-6 rounded-lg shadow" style={{ background: theme.cardBackground }}>

--- a/apps/examples/app/pages/dashboard.tsx
+++ b/apps/examples/app/pages/dashboard.tsx
@@ -1,31 +1,11 @@
 import { Effect, Layer } from "effect";
 import { Signal, Component } from "trygg";
-import { DashboardTheme, Analytics, Logger } from "../services/dashboard";
+import { Analytics, DashboardTheme, DashboardThemeLive, Logger } from "../services/dashboard";
 import { StatCard } from "../components/dashboard/stat-card";
 import { ActivityItem } from "../components/dashboard/activity-item";
 import { ActionButton } from "../components/dashboard/action-button";
 import { Header } from "../components/dashboard/header";
 import { SectionTitle } from "../components/dashboard/section-title";
-
-const lightTheme = Layer.succeed(DashboardTheme, {
-  name: "Light",
-  primary: "#0066cc",
-  secondary: "#6c757d",
-  background: "#f8f9fa",
-  cardBackground: "#ffffff",
-  text: "#212529",
-  textMuted: "#6c757d",
-});
-
-const darkTheme = Layer.succeed(DashboardTheme, {
-  name: "Dark",
-  primary: "#4da6ff",
-  secondary: "#adb5bd",
-  background: "#1a1a2e",
-  cardBackground: "#16213e",
-  text: "#e9ecef",
-  textMuted: "#adb5bd",
-});
 
 const analyticsLayer = Layer.succeed(Analytics, {
   track: (event, data) => Effect.log(`[Analytics] ${event}`, data),
@@ -36,91 +16,52 @@ const loggerLayer = Layer.succeed(Logger, {
   warn: (message) => Effect.log(`[WARN] ${message}`),
 });
 
+const activities = [
+  { text: "New user registered", time: "2 minutes ago" },
+  { text: "Order #1234 completed", time: "15 minutes ago" },
+  { text: "Payment received", time: "1 hour ago" },
+  { text: "Report generated", time: "3 hours ago" },
+];
+
 const DashboardPage = Component.gen(function* () {
-  const isDark = yield* Signal.make(false);
-  const isDarkValue = yield* Signal.get(isDark);
-
-  const currentTheme = isDarkValue ? darkTheme : lightTheme;
-  const theme = isDarkValue
-    ? {
-        name: "Dark",
-        primary: "#4da6ff",
-        background: "#1a1a2e",
-        text: "#e9ecef",
-        cardBackground: "#16213e",
-      }
-    : {
-        name: "Light",
-        primary: "#0066cc",
-        background: "#f8f9fa",
-        text: "#212529",
-        cardBackground: "#ffffff",
-      };
-
-  const toggleTheme = () => Signal.update(isDark, (v) => !v);
-
-  const activities = [
-    { text: "New user registered", time: "2 minutes ago" },
-    { text: "Order #1234 completed", time: "15 minutes ago" },
-    { text: "Payment received", time: "1 hour ago" },
-    { text: "Report generated", time: "3 hours ago" },
-  ];
-
-  // Partial provision: provide services based on current signal state
-  // Components have different requirements, so we provide different layer combinations
-  const ProvidedHeader = Header.pipe(
-    Component.provide(currentTheme),
-    Component.provide(loggerLayer),
-  );
-  const ProvidedStatCard = StatCard.pipe(Component.provide(currentTheme));
-  const ProvidedActionButton = ActionButton.pipe(
-    Component.provide(currentTheme),
-    Component.provide(analyticsLayer),
-  );
-  const ProvidedSectionTitle = SectionTitle.pipe(Component.provide(currentTheme));
-  const ProvidedActivityItem = ActivityItem.pipe(
-    Component.provide(currentTheme),
-    Component.provide(analyticsLayer),
-  );
+  const themeStore = yield* DashboardTheme;
+  const theme = yield* Signal.get(themeStore.tokens);
+  const switchLabel = yield* Signal.get(themeStore.switchLabel);
 
   return (
     <div className="min-h-screen font-sans -m-6 p-0" style={{ background: theme.background }}>
-      <ProvidedHeader userName="Developer" />
+      <Header userName="Developer" />
 
       <main className="p-6 max-w-300 mx-auto">
         <div className="flex justify-between items-center mb-6">
-          <ProvidedSectionTitle title="Overview" />
-          <ProvidedActionButton
-            label={`Switch to ${isDarkValue ? "Light" : "Dark"}`}
-            variant="secondary"
-            onClick={toggleTheme}
-          />
+          <SectionTitle title="Overview" />
+          <ActionButton label={switchLabel} variant="secondary" onClick={themeStore.toggle} />
         </div>
 
         <div className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 mb-8">
-          <ProvidedStatCard title="Total Users" value="12,345" change="+12%" />
-          <ProvidedStatCard title="Revenue" value="$45,678" change="+8%" />
-          <ProvidedStatCard title="Orders" value="1,234" change="-3%" />
-          <ProvidedStatCard title="Conversion" value="3.2%" change="+0.5%" />
+          <StatCard title="Total Users" value="12,345" change="+12%" />
+          <StatCard title="Revenue" value="$45,678" change="+8%" />
+          <StatCard title="Orders" value="1,234" change="-3%" />
+          <StatCard title="Conversion" value="3.2%" change="+0.5%" />
         </div>
 
-        <ProvidedSectionTitle title="Recent Activity" />
+        <SectionTitle title="Recent Activity" />
         <div
           className="rounded-lg overflow-hidden shadow"
           style={{ background: theme.cardBackground }}
         >
           {activities.map((activity, i) => (
-            <ProvidedActivityItem key={i} text={activity.text} time={activity.time} />
+            <ActivityItem key={i} text={activity.text} time={activity.time} />
           ))}
         </div>
 
         <div className="mt-8 flex gap-4">
-          <ProvidedActionButton
+          <ActionButton
             label="Generate Report"
             variant="primary"
             onClick={() => Effect.log("Generating report...")}
           />
-          <ProvidedActionButton
+          <ActionButton
             label="Export Data"
             variant="secondary"
             onClick={() => Effect.log("Exporting data...")}
@@ -131,4 +72,8 @@ const DashboardPage = Component.gen(function* () {
   );
 });
 
-export default DashboardPage;
+export default DashboardPage.pipe(
+  Component.provide(DashboardThemeLive),
+  Component.provide(analyticsLayer),
+  Component.provide(loggerLayer),
+);

--- a/docs/adr/0001-component-lifecycle-provision.md
+++ b/docs/adr/0001-component-lifecycle-provision.md
@@ -10,6 +10,7 @@ Trygg treats `.provide(layer)` as a component lifecycle boundary rather than a r
 - Store construction parameters are explicit config services composed with layers, not implicit component props.
 - Event handlers run with the provider context captured for their rendered element.
 - `Signal.makeSync` is removed rather than repositioned; reactive state should be created inside Effect scopes with `Signal.make`.
+- Disposed signal access is treated as a lifecycle defect, not a typed application error: public reads and writes keep clean `Effect` signatures, emit `signal.disposed_access` diagnostics, and fail loudly with `SignalDisposedError` as a defect so ErrorBoundary/debug tooling can observe stale lifecycle bugs.
 - General application services should be provided at component/layout boundaries; route-level provision is reserved for route strategies.
 - Component provision accepts one boundary layer per `Component.provide(layer)` call through the canonical pipeable API; repeated provision creates nested provider scopes with Effect-style semantics rather than merging layers in Trygg.
 - Layer composition, provision ordering, requirements narrowing, dependency satisfaction, and shadowing remain owned by Effect APIs and semantics.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -166,7 +166,7 @@ const themeLayer = Layer.succeed(Theme, { primary: "blue" });
 
 const App = Component.gen(function* () {
   return <Header />;
-}).provide(themeLayer);
+}).pipe(Component.provide(themeLayer));
 ```
 
 ### JSX Runtime Entry Points
@@ -177,30 +177,30 @@ JSX lowering details now live with the entrypoints themselves: [`src/jsx-runtime
 
 ### Core Exports
 
-| Export                                | Description                                        |
-| ------------------------------------- | -------------------------------------------------- |
-| `Component.gen(fn)`                   | Create component with explicit DI                  |
-| `Component.gen(fn).provide(layer)`    | Satisfy service requirements with a layer          |
-| `Signal.make(initial)`                | Create reactive state                              |
-| `Signal.get(signal)`                  | Read value and subscribe current render            |
-| `Signal.peek(signal)`                 | Read value without subscribing current render      |
-| `Signal.set(signal, value)`           | Set signal value                                   |
-| `Signal.update(signal, fn)`           | Update signal with function                        |
-| `Signal.derive(source, fn)`           | Computed signal from a source                      |
-| `Signal.deriveAll(sources, fn)`       | Computed signal from multiple sources              |
-| `Signal.each(source, fn, opts)`       | Efficient list rendering                           |
-| `Signal.suspend(component, handlers)` | Async component suspension                         |
-| `Resource.make(fn, opts)`             | Data fetching with cache and dedup                 |
-| `Resource.fetch(resource)`            | Fetch and return `ResourceState`                   |
-| `Resource.match(state, handlers)`     | Pattern-match on `Pending` / `Success` / `Failure` |
-| `Resource.invalidate(key)`            | Stale-while-revalidate a cached resource           |
-| `Resource.refresh(key)`               | Force re-fetch a cached resource                   |
-| `DevMode`                             | Enable debug output from JSX                       |
-| `ErrorBoundary`                       | Match tagged render failures                       |
-| `Portal`                              | Render into another DOM target                     |
-| `Head`                                | Head hoisting and dedup helpers                    |
-| `Debug`                               | Low-level debug events, plugins, spans             |
-| `Metrics`                             | Low-level framework metrics and sinks              |
+| Export                                | Description                                         |
+| ------------------------------------- | --------------------------------------------------- |
+| `Component.gen(fn)`                   | Create component with explicit DI                   |
+| `Component.provide(layer)`            | Satisfy component service requirements with a layer |
+| `Signal.make(initial)`                | Create reactive state                               |
+| `Signal.get(signal)`                  | Read value and subscribe current render             |
+| `Signal.peek(signal)`                 | Read value without subscribing current render       |
+| `Signal.set(signal, value)`           | Set signal value                                    |
+| `Signal.update(signal, fn)`           | Update signal with function                         |
+| `Signal.derive(source, fn)`           | Computed signal from a source                       |
+| `Signal.deriveAll(sources, fn)`       | Computed signal from multiple sources               |
+| `Signal.each(source, fn, opts)`       | Efficient list rendering                            |
+| `Signal.suspend(component, handlers)` | Async component suspension                          |
+| `Resource.make(fn, opts)`             | Data fetching with cache and dedup                  |
+| `Resource.fetch(resource)`            | Fetch and return `ResourceState`                    |
+| `Resource.match(state, handlers)`     | Pattern-match on `Pending` / `Success` / `Failure`  |
+| `Resource.invalidate(key)`            | Stale-while-revalidate a cached resource            |
+| `Resource.refresh(key)`               | Force re-fetch a cached resource                    |
+| `DevMode`                             | Enable debug output from JSX                        |
+| `ErrorBoundary`                       | Match tagged render failures                        |
+| `Portal`                              | Render into another DOM target                      |
+| `Head`                                | Head hoisting and dedup helpers                     |
+| `Debug`                               | Low-level debug events, plugins, spans              |
+| `Metrics`                             | Low-level framework metrics and sinks               |
 
 ### Router Exports
 


### PR DESCRIPTION
## Summary

- Refactors dashboard and nested-provide examples away from render-time provider switching and into stable lifecycle-provided scoped stores.
- Updates package README and lifecycle ADR guidance to show `Component.provide(layer)` as the pipeable component API.
- Documents the disposed signal DX decision: ordinary reads/writes keep clean signatures, while stale disposed access emits diagnostics and defects loudly.

## DX impact

- Examples now model the intended pattern: create scoped stores with `Layer.effect` + `Signal.make`, then provide those stores once at component lifecycle boundaries.
- Readers see a clear split between component service provision and route strategy provision.
- Signal disposal bugs stay observable without making every app callback carry `SignalDisposedError`.

## Acceptance criteria

- [x] Example guidance uses stable provider boundaries instead of dynamic layer swapping for UI state.
- [x] Docs describe pipeable `Component.provide(layer)` semantics.
- [x] Lifecycle ADR captures clean disposed-access DX and loud diagnostics.
- [x] Guidance remains aligned with the final scoped-signal API.

## Weird spots/spots needing attention

- Route strategy provision remains intentionally separate from component service provision.
- The ADR uses “defect” deliberately for disposed access because it is a lifecycle invariant violation, not a recoverable business error.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. **#225** 👈 current
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->