### PR TITLE
fix(core): close lifecycle provision review gaps

### DIFF
--- a/apps/examples/app/pages/home.tsx
+++ b/apps/examples/app/pages/home.tsx
@@ -23,8 +23,8 @@ const features = [
   {
     title: "Theme (DI)",
     path: "/theme",
-    description: "Dependency injection with Component.provide, swappable layers",
-    concepts: ["Context.Service", "Layer.succeed", "Component.provide", "Runtime switching"],
+    description: "Dependency injection with Component.provide and scoped signal stores",
+    concepts: ["Context.Service", "Layer.effect", "Component.provide", "Scoped state"],
   },
   {
     title: "Form Validation",

--- a/packages/core/src/primitives/__tests__/renderer.test.tsx
+++ b/packages/core/src/primitives/__tests__/renderer.test.tsx
@@ -2255,7 +2255,6 @@ describe("Re-render behavior", () => {
             querySchema: undefined,
             renderStrategy: undefined,
             scrollStrategy: undefined,
-            layers: [],
           },
         ],
         notFound: undefined,

--- a/packages/core/src/primitives/__tests__/signal.test.ts
+++ b/packages/core/src/primitives/__tests__/signal.test.ts
@@ -21,7 +21,19 @@
  */
 import { assert, describe, it } from "@effect/vitest";
 import { scoped } from "../../testing/effect-vitest.js";
-import { Cause, Data, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Result, Scope } from "effect";
+import {
+  Cause,
+  Data,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Option,
+  Ref,
+  Result,
+  Scope,
+} from "effect";
 import * as Context from "effect/Context";
 import { TestClock } from "effect/testing";
 import * as Signal from "../signal.js";

--- a/packages/core/src/primitives/component.docs.md
+++ b/packages/core/src/primitives/component.docs.md
@@ -146,6 +146,8 @@ const ValidatedForm = Component.gen(function* () {
 
 For dependency injection, children `yield*` services and parents decide where to provide them. Each `.pipe(Component.provide(layer))` narrows the remaining `R`; by the time an app reaches `mount`, the root effect must have `R = never`.
 
+A provided component owns a mounted provider boundary. Trygg acquires that layer once when the provided component mounts, reuses the provider scope while the component key and layer identity stay stable, and finalizes the scope on unmount. If the component key changes or a different layer instance is provided, Trygg treats that as replacement: the old provider finalizes and the replacement boundary acquires a fresh scope. Keep interactive state inside scoped services/signals provided by a stable boundary instead of swapping provider layers during render.
+
 Complex trees often need multiple interdependent services. Define services with `Context.Tag`, build layers that depend on other layers with `Layer.provideMerge`, and let the type system enforce that every requirement is satisfied before `mount`:
 
 ```tsx

--- a/packages/core/src/router/__tests__/outlet-rendering.test.ts
+++ b/packages/core/src/router/__tests__/outlet-rendering.test.ts
@@ -876,7 +876,6 @@ const loaderDefinition = (
   querySchema: undefined,
   renderStrategy: undefined,
   scrollStrategy: undefined,
-  layers: [],
 });
 
 describe("Outlet - Lazy loader (resolveComponent)", () => {

--- a/packages/core/src/router/__tests__/route-builder.test.ts
+++ b/packages/core/src/router/__tests__/route-builder.test.ts
@@ -378,13 +378,18 @@ describe("Route.provide", () => {
     assert.strictEqual(route.definition.scrollStrategy, ScrollStrategy.Auto);
   });
 
-  it("should handle multiple layers (RenderStrategy + ScrollStrategy)", () => {
+  it("should compose one route strategy per provide call", () => {
     const route = Route.make("/")
       .component(component)
-      .pipe(Route.provide(RenderStrategy.Eager, ScrollStrategy.None));
+      .pipe(Route.provide(RenderStrategy.Eager), Route.provide(ScrollStrategy.None));
 
     assert.strictEqual(route.definition.renderStrategy, RenderStrategy.Eager);
     assert.strictEqual(route.definition.scrollStrategy, ScrollStrategy.None);
+  });
+
+  it("rejects multi-strategy provision in one call", () => {
+    // @ts-expect-error Route.provide accepts one strategy layer per call.
+    Route.provide(RenderStrategy.Eager, ScrollStrategy.None);
   });
 
   it("should not store route service layers", () => {
@@ -400,11 +405,10 @@ describe("Route.provide", () => {
   it("should combine only strategy layers", () => {
     const route = Route.make("/")
       .component(component)
-      .pipe(Route.provide(RenderStrategy.Eager, ScrollStrategy.None));
+      .pipe(Route.provide(RenderStrategy.Eager), Route.provide(ScrollStrategy.None));
 
     assert.strictEqual(route.definition.renderStrategy, RenderStrategy.Eager);
     assert.strictEqual(route.definition.scrollStrategy, ScrollStrategy.None);
-    assert.strictEqual(route.definition.layers.length, 0);
   });
 
   it("should return a RouteBuilder (not an Effect)", () => {
@@ -448,7 +452,5 @@ describe("Route.provide", () => {
       typeof route extends Route.RouteBuilder<infer _P, infer R, infer _HC, infer _HCh> ? R : never;
     const _check: Equals<R, AuthService> = true;
     void _check;
-
-    assert.strictEqual(route.definition.layers.length, 0);
   });
 });

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -183,8 +183,8 @@ import { currentRoute as _currentRoute } from "./service.js";
 
 /**
  * Route namespace - provides `Route.make(path)`, `Route.index(component)`,
- * `Route.provide(...strategies)`, `Route.current`, `Route.redirect(path)`,
- * and `Route.forbidden()`.
+ * `Route.provide(strategy)`, `Route.current`, `Route.redirect(path)`, and
+ * `Route.forbidden()`.
  *
  * @remarks
  * Use `Route` for the fluent route-definition API. The namespace groups the

--- a/packages/core/src/router/link.ts
+++ b/packages/core/src/router/link.ts
@@ -43,19 +43,16 @@
  * @module trygg/router/link
  */
 import { Duration, Effect, Fiber } from "effect";
-import type { Any as AnyLayer, Layer as LayerType } from "effect/Layer";
 import * as Signal from "../primitives/signal.js";
 import {
   Element,
   intrinsic,
   type ElementProps,
   type AttributeInput,
-  provideElement,
 } from "../primitives/element.js";
 
 import * as Debug from "../debug/debug.js";
 import * as ContractTrace from "../contract/trace.js";
-import { unsafeWidenContext } from "../internal/unsafe.js";
 import { get as getRouter, Router } from "./service.js";
 import { buildPath } from "./utils.js";
 import type { HasKeys, RouteParamsFor, RoutePath } from "./types.js";
@@ -386,45 +383,21 @@ function LinkImpl<Path extends RoutePath>(props: LinkProps<Path>): Element {
   return Element.fromEffect(Effect.suspend(run), { identity: linkRuntimeIdentity, inputs: props });
 }
 
-// Define the Link component type with Component.Type properties
+// Define the Link component type with Component.Type properties.
 interface LinkComponent {
   <Path extends RoutePath>(props: LinkProps<Path>): Element;
   readonly _tag: "EffectComponent";
-  readonly _layers: ReadonlyArray<AnyLayer>;
+  readonly _layers: ReadonlyArray<unknown>;
   readonly _displayName: "Link";
-  provide<RIn, E2, ROut>(layer: LayerType<ROut, E2, RIn>): LinkComponent;
 }
 
-// Apply Component.Type properties to Link function
+// Apply Component.Type properties to Link function.
 const linkComponent: LinkComponent = Object.assign(
   <Path extends RoutePath>(props: LinkProps<Path>): Element => LinkImpl(props),
   {
     _tag: "EffectComponent" as const,
-    _layers: [] as ReadonlyArray<AnyLayer>,
+    _layers: [] as ReadonlyArray<unknown>,
     _displayName: "Link" as const,
-    provide: <RIn, E2, ROut>(layer: LayerType<ROut, E2, RIn>): LinkComponent => {
-      const wrappedLink: LinkComponent = Object.assign(
-        <Path extends RoutePath>(props: LinkProps<Path>): Element => {
-          const run = (): Effect.Effect<Element, E2, RIn> =>
-            Effect.gen(function* () {
-              const context = yield* Effect.context<ROut>().pipe(
-                Effect.provide(layer),
-                Effect.map((ctx) => unsafeWidenContext(ctx)),
-              );
-              const element = LinkImpl(props);
-              return provideElement(context, element);
-            });
-          return Element.fromEffect(Effect.suspend(run), { identity: wrappedLink, inputs: props });
-        },
-        {
-          _tag: "EffectComponent" as const,
-          _layers: [layer] as ReadonlyArray<AnyLayer>,
-          _displayName: "Link" as const,
-          provide: linkComponent.provide,
-        },
-      );
-      return wrappedLink;
-    },
   },
 );
 

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -66,7 +66,7 @@ import {
   type RouteParams,
 } from "./types.js";
 import { getFiberRef, setFiberRef } from "../internal/fiber-ref.js";
-import { unsafeBuildContext, unsafeEraseR } from "../internal/unsafe.js";
+import { unsafeEraseR } from "../internal/unsafe.js";
 
 const outletRuntimeIdentity = Symbol("trygg/router/Outlet.runtime");
 const outletErrorBoundaryIdentity = Symbol("trygg/router/Outlet.error-boundary");
@@ -701,7 +701,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
     // Sub-effects for processRoute (closures capturing outletEffect scope)
     // -------------------------------------------------------------------------
 
-    /** Resolve component + layouts, stack root-to-leaf, provide service layers. */
+    /** Resolve component + layouts and stack root-to-leaf. */
     const buildRouteElement = (
       match: RouteMatch,
       decodedParams: Record<string, unknown>,
@@ -800,16 +800,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
         );
       });
 
-      const allLayers = [
-        ...match.route.ancestors.flatMap((a) => (a !== undefined ? a.definition.layers : [])),
-        ...match.route.definition.layers,
-      ];
-
-      return allLayers.length > 0
-        ? Effect.flatMap(unsafeBuildContext<unknown>(allLayers), (services) =>
-            Effect.provide(renderBase, services),
-          )
-        : renderBase;
+      return renderBase;
     };
 
     /** Wrap render effect with nearest-wins error boundary. */

--- a/packages/core/src/router/route.ts
+++ b/packages/core/src/router/route.ts
@@ -108,7 +108,6 @@ export interface RouteDefinition {
   readonly querySchema: unknown | undefined;
   readonly renderStrategy: LayerTypes.Layer<RenderStrategy> | undefined;
   readonly scrollStrategy: LayerTypes.Layer<ScrollStrategy> | undefined;
-  readonly layers: ReadonlyArray<LayerTypes.Any>;
 }
 
 // =============================================================================
@@ -516,7 +515,6 @@ const emptyDefinition = (path: string | IndexMarker): RouteDefinition => ({
   querySchema: undefined,
   renderStrategy: undefined,
   scrollStrategy: undefined,
-  layers: [],
 });
 
 // =============================================================================
@@ -637,7 +635,7 @@ const isScrollStrategyLayer = (
  *
  * Route.make("/settings")
  *   .component(SettingsPage)
- *   .pipe(Route.provide(RenderStrategy.Eager, ScrollStrategy.None))
+ *   .pipe(Route.provide(RenderStrategy.Eager), Route.provide(ScrollStrategy.None))
  * ```
  *
  * @remarks
@@ -660,41 +658,6 @@ export function provide(
   HEB extends boolean,
 >(
   builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
-) => RouteBuilder<Path, R, HC, HCh, NC, HEB>;
-
-/**
- * Apply multiple strategy layers to a route.
- *
- * @category Route Builders
- * @public
- * @since 1.0.0
- */
-export function provide(
-  layer1: RouteStrategyLayer,
-  layer2: RouteStrategyLayer,
-  ...rest: Array<RouteStrategyLayer>
-): <
-  Path extends string,
-  R,
-  HC extends boolean,
-  HCh extends boolean,
-  NC extends boolean,
-  HEB extends boolean,
->(
-  builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
-) => RouteBuilder<Path, R, HC, HCh, NC, HEB>;
-
-export function provide(
-  ...layers: ReadonlyArray<RouteStrategyLayer>
-): <
-  Path extends string,
-  R,
-  HC extends boolean,
-  HCh extends boolean,
-  NC extends boolean,
-  HEB extends boolean,
->(
-  builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
 ) => RouteBuilder<Path, R, HC, HCh, NC, HEB> {
   return <
     Path extends string,
@@ -706,24 +669,13 @@ export function provide(
   >(
     builder: RouteBuilder<Path, R, HC, HCh, NC, HEB>,
   ): RouteBuilder<Path, R, HC, HCh, NC, HEB> => {
-    let renderStrategy: LayerTypes.Layer<RenderStrategy> | undefined =
-      builder.definition.renderStrategy;
-    let scrollStrategy: LayerTypes.Layer<ScrollStrategy> | undefined =
-      builder.definition.scrollStrategy;
-
-    for (const layer of layers) {
-      if (isRenderStrategyLayer(layer)) {
-        renderStrategy = layer;
-      } else if (isScrollStrategyLayer(layer)) {
-        scrollStrategy = layer;
-      }
-    }
+    const renderStrategy = isRenderStrategyLayer(layer) ? layer : builder.definition.renderStrategy;
+    const scrollStrategy = isScrollStrategyLayer(layer) ? layer : builder.definition.scrollStrategy;
 
     return makeBuilder<Path, R, HC, HCh, NC, HEB>({
       ...builder.definition,
       renderStrategy,
       scrollStrategy,
-      layers: builder.definition.layers,
     });
   };
 }


### PR DESCRIPTION
## Summary

- Removes the remaining public `Link.provide(...)` method-style provision API.
- Removes legacy route service-layer storage/application from route definitions and outlet rendering.
- Makes `Route.provide` singular so multiple route strategies compose through multiple pipe steps.
- Updates lifecycle guidance/docs and example copy to match stable provider-boundary semantics.

## DX impact

Before:

```tsx
Link.provide(AuthLive)
Route.make("/").pipe(Route.provide(RenderStrategy.Eager, ScrollStrategy.None))
```

After:

```tsx
Link.pipe(Component.provide(AuthLive))
Route.make("/").pipe(Route.provide(RenderStrategy.Eager), Route.provide(ScrollStrategy.None))
```

This keeps provision syntax consistent: component services use `Component.provide(layer)` at lifecycle boundaries, while route strategies compose one strategy per pipe step.

## Acceptance criteria

- [x] `Link.provide(...)` is removed from the public API and docs/tests use pipeable component provision.
- [x] Route definitions no longer store service layers.
- [x] `Route.provide` accepts a single strategy per call.
- [x] Tests/docs cover the intended route/component provision split.

## Weird spots/spots needing attention

- This PR intentionally keeps route strategy provision separate from service/layer provision; service layers belong at component boundaries.
- Existing examples with multiple route strategies now use multiple `Route.provide(...)` pipe steps for clarity.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. **#244** 👈 current
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->