### PR TITLE
feat(core): add route path pattern contract

### DIFF
--- a/packages/core/src/router/__tests__/path-pattern.test.ts
+++ b/packages/core/src/router/__tests__/path-pattern.test.ts
@@ -1,0 +1,110 @@
+import { assert, describe, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import {
+  compileRoutePathPattern,
+  compareCompiledRoutePathPatterns,
+  matchCompiledRoutePathPattern,
+  RoutePathPattern,
+} from "../path-pattern.js";
+
+const compile = (pattern: string) => compileRoutePathPattern(pattern);
+
+describe("RoutePathPattern", () => {
+  it.effect("classifies static, param, wildcard, and required catch-all segments", () =>
+    Effect.gen(function* () {
+      const pattern = yield* compile("/docs/:section/:path*/files/:filepath+");
+
+      assert.deepStrictEqual(pattern.segments, [
+        { _tag: "Static", value: "docs" },
+        { _tag: "Param", name: "section" },
+        { _tag: "Wildcard", name: "path" },
+        { _tag: "Static", value: "files" },
+        { _tag: "CatchAllRequired", name: "filepath" },
+      ]);
+      assert.deepStrictEqual(pattern.paramNames, ["section", "path", "filepath"]);
+    }),
+  );
+
+  it.effect("matches static and param paths", () =>
+    Effect.gen(function* () {
+      const pattern = yield* compile("/users/:id");
+      const match = matchCompiledRoutePathPattern(pattern, "/users/123");
+
+      assert.isTrue(Option.isSome(match));
+      if (Option.isSome(match)) {
+        assert.deepStrictEqual(match.value.params, { id: "123" });
+      }
+    }),
+  );
+
+  it.effect("matches wildcard with zero or more segments", () =>
+    Effect.gen(function* () {
+      const pattern = yield* compile("/docs/:path*");
+      const rootMatch = matchCompiledRoutePathPattern(pattern, "/docs");
+      const nestedMatch = matchCompiledRoutePathPattern(pattern, "/docs/api/users");
+
+      assert.isTrue(Option.isSome(rootMatch));
+      assert.isTrue(Option.isSome(nestedMatch));
+      if (Option.isSome(rootMatch)) assert.strictEqual(rootMatch.value.params.path, "");
+      if (Option.isSome(nestedMatch)) {
+        assert.strictEqual(nestedMatch.value.params.path, "api/users");
+      }
+    }),
+  );
+
+  it.effect("requires at least one segment for required catch-all", () =>
+    Effect.gen(function* () {
+      const pattern = yield* compile("/files/:filepath+");
+
+      assert.isTrue(Option.isNone(matchCompiledRoutePathPattern(pattern, "/files")));
+
+      const match = matchCompiledRoutePathPattern(pattern, "/files/a/b.txt");
+      assert.isTrue(Option.isSome(match));
+      if (Option.isSome(match)) assert.strictEqual(match.value.params.filepath, "a/b.txt");
+    }),
+  );
+
+  it.effect("normalizes root, index-compatible, and trailing slash paths", () =>
+    Effect.gen(function* () {
+      const root = yield* compile("/");
+      const alsoRoot = yield* compile("///");
+      const users = yield* compile("/users/");
+
+      assert.deepStrictEqual(root.segments, []);
+      assert.deepStrictEqual(alsoRoot.segments, []);
+      assert.strictEqual(users.pattern, "/users");
+      assert.isTrue(Option.isSome(matchCompiledRoutePathPattern(root, "/")));
+      assert.isTrue(Option.isNone(matchCompiledRoutePathPattern(root, "/users")));
+      assert.isTrue(Option.isSome(matchCompiledRoutePathPattern(users, "/users/")));
+    }),
+  );
+
+  it.effect("sorts by route matching precedence", () =>
+    Effect.gen(function* () {
+      const patterns = yield* Effect.forEach(
+        ["/docs/:path*", "/docs/:path+", "/docs/:id", "/docs/settings"],
+        compile,
+      );
+
+      const sorted = [...patterns].sort(compareCompiledRoutePathPatterns);
+
+      assert.deepStrictEqual(
+        sorted.map((pattern) => pattern.pattern),
+        ["/docs/settings", "/docs/:id", "/docs/:path+", "/docs/:path*"],
+      );
+    }),
+  );
+
+  it.effect("exposes compile, compare, and match through the service", () =>
+    Effect.gen(function* () {
+      const service = yield* RoutePathPattern;
+      const staticPattern = yield* service.compile("/users/settings");
+      const paramPattern = yield* service.compile("/users/:id");
+      const order = yield* service.compare(staticPattern, paramPattern);
+      const match = yield* service.match(paramPattern, "/users/42");
+
+      assert.isBelow(order, 0);
+      assert.isTrue(Option.isSome(match));
+    }).pipe(Effect.provide(RoutePathPattern.layer({ normalizeTrailingSlash: true }))),
+  );
+});

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -129,6 +129,21 @@ export {
 } from "./matching.js";
 export type { ResolvedRoute, RouteMatch, RouteMatcherShape, SyncMatcher } from "./matching.js";
 
+// Route Path Pattern
+export {
+  RoutePathPattern,
+  compileRoutePathPattern,
+  compareCompiledRoutePathPatterns,
+  matchCompiledRoutePathPattern,
+  InvalidRoutePathPattern,
+  RoutePathPatternConfigInput,
+} from "./path-pattern.js";
+export type {
+  RoutePathSegment,
+  CompiledRoutePathPattern,
+  RoutePathPatternMatch,
+} from "./path-pattern.js";
+
 // Route Builder
 export {
   make as routeMake,

--- a/packages/core/src/router/matching.ts
+++ b/packages/core/src/router/matching.ts
@@ -26,6 +26,12 @@ import type { RoutesManifest } from "./routes.js";
 import type { RenderStrategy } from "./render-strategy.js";
 import type { ScrollStrategy } from "./scroll-strategy.js";
 import type { ComponentInput, RouteParams } from "./types.js";
+import {
+  compileRoutePathPattern,
+  compareCompiledRoutePathPatterns,
+  matchCompiledRoutePathPattern,
+  type CompiledRoutePathPattern,
+} from "./path-pattern.js";
 
 const fromNullable = <A>(value: A | null | undefined): Option.Option<A> =>
   value === null || value === undefined ? Option.none() : Option.some(value);
@@ -137,9 +143,9 @@ export class RouteMatcher extends Context.Service<RouteMatcher, RouteMatcherShap
       RouteMatcher,
       Effect.gen(function* () {
         const resolved = yield* resolveRoutes(manifest);
-        const sorted = sortRoutesForMatching(resolved);
+        const matcher = yield* makeLinearMatcher(resolved);
         return {
-          match: (path: string) => Effect.succeed(linearMatch(sorted, path)),
+          match: matcher.match,
           routes: Effect.succeed(resolved),
         };
       }),
@@ -147,10 +153,16 @@ export class RouteMatcher extends Context.Service<RouteMatcher, RouteMatcherShap
 
   /** Create a RouteMatcher Layer from resolved routes using linear scan (for testing). */
   static readonly test = (routes: ReadonlyArray<ResolvedRoute>): LayerType<RouteMatcher> =>
-    Layer.succeed(RouteMatcher, {
-      match: (path: string) => Effect.succeed(linearMatch(routes, path)),
-      routes: Effect.succeed(routes),
-    });
+    Layer.effect(
+      RouteMatcher,
+      Effect.gen(function* () {
+        const matcher = yield* makeLinearMatcher(routes);
+        return {
+          match: matcher.match,
+          routes: Effect.succeed(routes),
+        };
+      }),
+    );
 }
 
 // =============================================================================
@@ -234,143 +246,53 @@ const resolvePath = (path: string | typeof IndexMarker, parentPath: string): str
 };
 
 // =============================================================================
-// Segment Parsing
+// Path Pattern Matching
 // =============================================================================
 
-/** @internal */
-interface PathSegment {
-  readonly type: "static" | "param" | "wildcard" | "catchAllRequired";
-  readonly value: string;
+interface CompiledRouteMatcherEntry {
+  readonly route: ResolvedRoute;
+  readonly pattern: CompiledRoutePathPattern;
 }
 
-/** @internal */
-const parsePattern = (pattern: string): { segments: PathSegment[]; paramNames: string[] } => {
-  const segments: PathSegment[] = [];
-  const paramNames: string[] = [];
-
-  const parts = pattern
-    .replace(/^\/|\/$/g, "")
-    .split("/")
-    .filter(Boolean);
-
-  for (const part of parts) {
-    if (part.startsWith(":") && part.endsWith("*")) {
-      const name = part.slice(1, -1);
-      segments.push({ type: "wildcard", value: name });
-      paramNames.push(name);
-    } else if (part.startsWith(":") && part.endsWith("+")) {
-      const name = part.slice(1, -1);
-      segments.push({ type: "catchAllRequired", value: name });
-      paramNames.push(name);
-    } else if (part.startsWith(":")) {
-      const name = part.slice(1);
-      segments.push({ type: "param", value: name });
-      paramNames.push(name);
-    } else {
-      segments.push({ type: "static", value: part });
-    }
-  }
-
-  return { segments, paramNames };
-};
-
-/** @internal */
-const scoreRoute = (segments: ReadonlyArray<PathSegment>): number => {
-  let score = 0;
-  for (const segment of segments) {
-    if (segment.type === "static") {
-      score += 3;
-    } else if (segment.type === "param") {
-      score += 2;
-    } else if (segment.type === "catchAllRequired") {
-      score += 1.5;
-    } else if (segment.type === "wildcard") {
-      score += 1;
-    }
-  }
-  score += segments.length * 0.1;
-  return score;
-};
-
-/** @internal */
-const sortRoutesForMatching = (
+const compileRoutesForMatching = (
   routes: ReadonlyArray<ResolvedRoute>,
-): ReadonlyArray<ResolvedRoute> =>
-  [...routes].sort((a, b) => {
-    const aSegments = parsePattern(a.path).segments;
-    const bSegments = parsePattern(b.path).segments;
-    if (aSegments.length !== bSegments.length) {
-      return bSegments.length - aSegments.length;
-    }
-    return scoreRoute(bSegments) - scoreRoute(aSegments);
-  });
+): Effect.Effect<ReadonlyArray<CompiledRouteMatcherEntry>> =>
+  Effect.forEach(routes, (route) =>
+    Effect.map(compileRoutePathPattern(route.path), (pattern) => ({ route, pattern })).pipe(
+      Effect.orDie,
+    ),
+  );
 
-/**
- * Linear scan match function for testing.
- * @internal
- */
-const linearMatch = (
-  routes: ReadonlyArray<ResolvedRoute>,
+const sortCompiledRoutesForMatching = (
+  routes: ReadonlyArray<CompiledRouteMatcherEntry>,
+): ReadonlyArray<CompiledRouteMatcherEntry> =>
+  [...routes].sort((left, right) =>
+    compareCompiledRoutePathPatterns(left.pattern, right.pattern),
+  );
+
+const linearMatchCompiled = (
+  routes: ReadonlyArray<CompiledRouteMatcherEntry>,
   path: string,
 ): Option.Option<RouteMatch> => {
-  const normalizedPath = path.split("?")[0] ?? path;
-  const pathParts = normalizedPath
-    .replace(/^\/|\/$/g, "")
-    .split("/")
-    .filter(Boolean);
-
   for (const route of routes) {
-    const { segments } = parsePattern(route.path);
-    const params: RouteParams = {};
-    let matched = true;
-
-    if (segments.length === 0 && pathParts.length === 0) {
-      return Option.some({ route, params });
-    }
-
-    let pathIdx = 0;
-    for (let i = 0; i < segments.length; i++) {
-      const seg = segments[i];
-      if (seg === undefined) {
-        matched = false;
-        break;
-      }
-
-      if (seg.type === "static") {
-        if (pathParts[pathIdx] !== seg.value) {
-          matched = false;
-          break;
-        }
-        pathIdx++;
-      } else if (seg.type === "param") {
-        const part = pathParts[pathIdx];
-        if (part === undefined) {
-          matched = false;
-          break;
-        }
-        params[seg.value] = part;
-        pathIdx++;
-      } else if (seg.type === "wildcard") {
-        params[seg.value] = pathParts.slice(pathIdx).join("/");
-        pathIdx = pathParts.length;
-      } else if (seg.type === "catchAllRequired") {
-        const rest = pathParts.slice(pathIdx).join("/");
-        if (rest === "") {
-          matched = false;
-          break;
-        }
-        params[seg.value] = rest;
-        pathIdx = pathParts.length;
-      }
-    }
-
-    if (matched && pathIdx === pathParts.length) {
-      return Option.some({ route, params });
+    const match = matchCompiledRoutePathPattern(route.pattern, path);
+    if (Option.isSome(match)) {
+      return Option.some({ route: route.route, params: match.value.params });
     }
   }
 
   return Option.none();
 };
+
+const makeLinearMatcher = (
+  routes: ReadonlyArray<ResolvedRoute>,
+): Effect.Effect<{ readonly match: (path: string) => Effect.Effect<Option.Option<RouteMatch>> }> =>
+  Effect.map(compileRoutesForMatching(routes), (compiled) => {
+    const sorted = sortCompiledRoutesForMatching(compiled);
+    return {
+      match: (path: string) => Effect.succeed(linearMatchCompiled(sorted, path)),
+    };
+  });
 
 // =============================================================================
 // Middleware Collection & Execution
@@ -714,10 +636,11 @@ export interface SyncMatcher {
  * @since 1.0.0
  */
 export const createMatcher = (manifest: RoutesManifest): Effect.Effect<SyncMatcher> =>
-  Effect.map(resolveRoutes(manifest), (resolved) => {
-    const sorted = sortRoutesForMatching(resolved);
+  Effect.gen(function* () {
+    const resolved = yield* resolveRoutes(manifest);
+    const compiled = sortCompiledRoutesForMatching(yield* compileRoutesForMatching(resolved));
     return {
-      match: (path) => linearMatch(sorted, path),
+      match: (path) => linearMatchCompiled(compiled, path),
       routes: resolved,
     };
   });

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -49,6 +49,12 @@ import { get as getRouter, CurrentOutletChild } from "./service.js";
 import { runPrefetch } from "./prefetch.js";
 import { parsePath } from "./utils.js";
 import {
+  compileRoutePathPattern,
+  compareCompiledRoutePathPatterns,
+  type CompiledRoutePathPattern,
+  type RoutePathSegment,
+} from "./path-pattern.js";
+import {
   BoundaryResolver,
   AsyncLoader,
   renderComponent,
@@ -77,16 +83,9 @@ const outletLazyLeafIdentity = Symbol("trygg/router/Outlet.lazy-leaf");
 // =============================================================================
 
 /** @internal */
-interface PathSegment {
-  readonly type: "static" | "param" | "wildcard" | "catchAllRequired";
-  readonly value: string;
-}
-
-/** @internal */
 interface CompiledRoute {
   readonly resolved: ResolvedRoute;
-  readonly segments: ReadonlyArray<PathSegment>;
-  readonly score: number;
+  readonly pattern: CompiledRoutePathPattern;
 }
 
 /** @internal */
@@ -104,29 +103,6 @@ interface TrieMatchResult {
 }
 
 /** @internal */
-const parsePattern = (pattern: string): ReadonlyArray<PathSegment> => {
-  const segments: Array<PathSegment> = [];
-  const parts = pattern
-    .replace(/^\/|\/$/g, "")
-    .split("/")
-    .filter(Boolean);
-
-  for (const part of parts) {
-    if (part.startsWith(":") && part.endsWith("*")) {
-      segments.push({ type: "wildcard", value: part.slice(1, -1) });
-    } else if (part.startsWith(":") && part.endsWith("+")) {
-      segments.push({ type: "catchAllRequired", value: part.slice(1, -1) });
-    } else if (part.startsWith(":")) {
-      segments.push({ type: "param", value: part.slice(1) });
-    } else {
-      segments.push({ type: "static", value: part });
-    }
-  }
-
-  return segments;
-};
-
-/** @internal */
 const createTrieNode = (): TrieNode => ({
   staticChildren: new Map(),
   paramChild: undefined,
@@ -135,43 +111,28 @@ const createTrieNode = (): TrieNode => ({
 });
 
 /** @internal */
-const scoreRoute = (segments: ReadonlyArray<PathSegment>): number => {
-  let score = 0;
-  for (const segment of segments) {
-    if (segment.type === "static") {
-      score += 3;
-    } else if (segment.type === "param") {
-      score += 2;
-    } else if (segment.type === "catchAllRequired") {
-      score += 1.5;
-    } else if (segment.type === "wildcard") {
-      score += 1;
-    }
-  }
-  score += segments.length * 0.1;
-  return score;
-};
+const segmentName = (segment: Extract<RoutePathSegment, { readonly _tag: "Param" | "Wildcard" | "CatchAllRequired" }>): string => segment.name;
 
 /** @internal */
 const insertIntoTrie = (root: TrieNode, route: CompiledRoute): void => {
   let current = root;
 
-  for (const segment of route.segments) {
-    if (segment.type === "static") {
+  for (const segment of route.pattern.segments) {
+    if (segment._tag === "Static") {
       let child = current.staticChildren.get(segment.value);
       if (child === undefined) {
         child = createTrieNode();
         current.staticChildren.set(segment.value, child);
       }
       current = child;
-    } else if (segment.type === "param") {
+    } else if (segment._tag === "Param") {
       if (current.paramChild === undefined) {
-        current.paramChild = { node: createTrieNode(), name: segment.value };
+        current.paramChild = { node: createTrieNode(), name: segmentName(segment) };
       }
       current = current.paramChild.node;
-    } else if (segment.type === "wildcard" || segment.type === "catchAllRequired") {
+    } else if (segment._tag === "Wildcard" || segment._tag === "CatchAllRequired") {
       if (current.wildcardChild === undefined) {
-        current.wildcardChild = { node: createTrieNode(), name: segment.value };
+        current.wildcardChild = { node: createTrieNode(), name: segmentName(segment) };
       }
       current = current.wildcardChild.node;
       break;
@@ -192,11 +153,11 @@ const walkTrie = (
 
   if (pathIndex >= pathParts.length) {
     for (const route of node.routes) {
-      const lastSegment = route.segments[route.segments.length - 1];
+      const lastSegment = route.pattern.segments[route.pattern.segments.length - 1];
       if (
-        lastSegment?.type !== "wildcard" &&
-        lastSegment?.type !== "catchAllRequired" &&
-        route.segments.length === pathIndex
+        lastSegment?._tag !== "Wildcard" &&
+        lastSegment?._tag !== "CatchAllRequired" &&
+        route.pattern.segments.length === pathIndex
       ) {
         results.push({ route, params: { ...params } });
       }
@@ -204,8 +165,8 @@ const walkTrie = (
     if (node.wildcardChild !== undefined) {
       const newParams = { ...params, [node.wildcardChild.name]: "" };
       for (const route of node.wildcardChild.node.routes) {
-        const lastSeg = route.segments[route.segments.length - 1];
-        if (lastSeg?.type === "wildcard") {
+        const lastSeg = route.pattern.segments[route.pattern.segments.length - 1];
+        if (lastSeg?._tag === "Wildcard") {
           results.push({ route, params: { ...newParams } });
         }
       }
@@ -230,8 +191,8 @@ const walkTrie = (
     const rest = pathParts.slice(pathIndex).join("/");
     const newParams = { ...params, [node.wildcardChild.name]: rest };
     for (const route of node.wildcardChild.node.routes) {
-      const lastSeg = route.segments[route.segments.length - 1];
-      if (lastSeg?.type !== "catchAllRequired" || rest !== "") {
+      const lastSeg = route.pattern.segments[route.pattern.segments.length - 1];
+      if (lastSeg?._tag !== "CatchAllRequired" || rest !== "") {
         results.push({ route, params: { ...newParams } });
       }
     }
@@ -243,18 +204,18 @@ const walkTrie = (
 /** @internal */
 export const buildTrieMatcher = (
   resolved: ReadonlyArray<ResolvedRoute>,
-): ((path: string) => Option.Option<RouteMatch>) => {
-  const compiled = resolved.map((route): CompiledRoute => {
-    const segments = parsePattern(route.path);
-    return { resolved: route, segments, score: scoreRoute(segments) };
-  });
+): Effect.Effect<(path: string) => Option.Option<RouteMatch>> =>
+  Effect.gen(function* () {
+    const compiled = yield* Effect.forEach(resolved, (route) =>
+      Effect.map(compileRoutePathPattern(route.path), (pattern): CompiledRoute => ({
+        resolved: route,
+        pattern,
+      })).pipe(Effect.orDie),
+    );
 
-  const sorted = [...compiled].sort((a, b) => {
-    if (a.segments.length !== b.segments.length) {
-      return b.segments.length - a.segments.length;
-    }
-    return b.score - a.score;
-  });
+    const sorted = [...compiled].sort((a, b) =>
+      compareCompiledRoutePathPatterns(a.pattern, b.pattern),
+    );
 
   const root = createTrieNode();
   for (const route of sorted) {
@@ -271,19 +232,16 @@ export const buildTrieMatcher = (
     const matches = walkTrie(root, pathParts, 0, {});
     if (matches.length === 0) return Option.none();
 
-    const sortedMatches = [...matches].sort((a, b) => {
-      if (a.route.segments.length !== b.route.segments.length) {
-        return b.route.segments.length - a.route.segments.length;
-      }
-      return b.route.score - a.route.score;
-    });
+    const sortedMatches = [...matches].sort((a, b) =>
+      compareCompiledRoutePathPatterns(a.route.pattern, b.route.pattern),
+    );
 
     const best = sortedMatches[0];
     if (best === undefined) return Option.none();
 
     return Option.some({ route: best.route.resolved, params: best.params });
   };
-};
+});
 
 // =============================================================================
 // Schema Validation for RouteComponent
@@ -581,7 +539,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
 
     if (Option.isNone(cachedMatcher) || manifestChanged) {
       const resolved = yield* resolveRoutes(manifest);
-      const matchFn = buildTrieMatcher(resolved);
+      const matchFn = yield* buildTrieMatcher(resolved);
       const shape: RouteMatcherShape = {
         match: (path) => Effect.succeed(matchFn(path)),
         routes: Effect.succeed(resolved),

--- a/packages/core/src/router/path-pattern.ts
+++ b/packages/core/src/router/path-pattern.ts
@@ -1,0 +1,219 @@
+/**
+ * Canonical route path-pattern semantics for `trygg/router`.
+ *
+ * @remarks
+ * This module owns route path parsing, segment classification, precedence scoring,
+ * and pathname matching so Link, Router, RouteMatcher, and generated route metadata
+ * can share one source of truth.
+ *
+ * @since 1.0.0
+ * @module trygg/router/path-pattern
+ */
+import { Data, Effect, Layer, Option, Schema } from "effect";
+import * as Context from "effect/Context";
+
+/** A compiled route path segment. */
+export type RoutePathSegment =
+  | { readonly _tag: "Static"; readonly value: string }
+  | { readonly _tag: "Param"; readonly name: string }
+  | { readonly _tag: "Wildcard"; readonly name: string }
+  | { readonly _tag: "CatchAllRequired"; readonly name: string };
+
+/** Canonical compiled representation of a route path pattern. */
+export interface CompiledRoutePathPattern {
+  readonly pattern: string;
+  readonly segments: ReadonlyArray<RoutePathSegment>;
+  readonly paramNames: ReadonlyArray<string>;
+  readonly score: number;
+}
+
+/** Successful route path-pattern match. */
+export interface RoutePathPatternMatch {
+  readonly pattern: CompiledRoutePathPattern;
+  readonly params: Readonly<Record<string, string>>;
+}
+
+/** Domain failure for invalid route path-pattern syntax. */
+export class InvalidRoutePathPattern extends Data.TaggedError("InvalidRoutePathPattern")<{
+  readonly pattern: string;
+  readonly reason: string;
+}> {}
+
+/** Route path-pattern service config. */
+export const RoutePathPatternConfigInput = Schema.Struct({
+  normalizeTrailingSlash: Schema.Boolean,
+});
+
+type RoutePathPatternConfig = typeof RoutePathPatternConfigInput.Type;
+
+const normalizePattern = (pattern: string, config: RoutePathPatternConfig): string => {
+  if (!config.normalizeTrailingSlash || pattern === "/") {
+    return pattern;
+  }
+  return pattern.replace(/\/+$/u, "") || "/";
+};
+
+const splitPath = (path: string, config: RoutePathPatternConfig): ReadonlyArray<string> => {
+  const normalized = normalizePattern(path.split(/[?#]/u)[0] ?? path, config);
+  return normalized
+    .replace(/^\/|\/$/gu, "")
+    .split("/")
+    .filter(Boolean);
+};
+
+const segmentScore = (segment: RoutePathSegment): number => {
+  switch (segment._tag) {
+    case "Static":
+      return 3;
+    case "Param":
+      return 2;
+    case "CatchAllRequired":
+      return 1.5;
+    case "Wildcard":
+      return 1;
+  }
+};
+
+const scoreSegments = (segments: ReadonlyArray<RoutePathSegment>): number =>
+  segments.reduce((score, segment) => score + segmentScore(segment), 0) + segments.length * 0.1;
+
+const parseParamName = (
+  pattern: string,
+  rawName: string,
+): Effect.Effect<string, InvalidRoutePathPattern> => {
+  if (rawName.length === 0) {
+    return Effect.fail(new InvalidRoutePathPattern({ pattern, reason: "param name is empty" }));
+  }
+  if (rawName.includes(":")) {
+    return Effect.fail(new InvalidRoutePathPattern({ pattern, reason: `invalid param name '${rawName}'` }));
+  }
+  return Effect.succeed(rawName);
+};
+
+/** Compile a route path pattern into its canonical segment model. */
+export const compileRoutePathPattern = (
+  pattern: string,
+  config: RoutePathPatternConfig = { normalizeTrailingSlash: true },
+): Effect.Effect<CompiledRoutePathPattern, InvalidRoutePathPattern> =>
+  Effect.gen(function* () {
+    const normalized = normalizePattern(pattern, config);
+    const segments: Array<RoutePathSegment> = [];
+    const paramNames: Array<string> = [];
+
+    for (const part of splitPath(normalized, config)) {
+      if (part.startsWith(":")) {
+        if (part.endsWith("*")) {
+          const name = yield* parseParamName(normalized, part.slice(1, -1));
+          segments.push({ _tag: "Wildcard", name });
+          paramNames.push(name);
+        } else if (part.endsWith("+")) {
+          const name = yield* parseParamName(normalized, part.slice(1, -1));
+          segments.push({ _tag: "CatchAllRequired", name });
+          paramNames.push(name);
+        } else {
+          const name = yield* parseParamName(normalized, part.slice(1));
+          segments.push({ _tag: "Param", name });
+          paramNames.push(name);
+        }
+      } else {
+        segments.push({ _tag: "Static", value: part });
+      }
+    }
+
+    return {
+      pattern: normalized,
+      segments,
+      paramNames,
+      score: scoreSegments(segments),
+    };
+  });
+
+/** Sort comparator: more specific patterns come first. */
+export const compareCompiledRoutePathPatterns = (
+  left: CompiledRoutePathPattern,
+  right: CompiledRoutePathPattern,
+): number => {
+  if (left.segments.length !== right.segments.length) {
+    return right.segments.length - left.segments.length;
+  }
+  return right.score - left.score;
+};
+
+/** Match a compiled route path pattern against a pathname. */
+export const matchCompiledRoutePathPattern = (
+  pattern: CompiledRoutePathPattern,
+  pathname: string,
+  config: RoutePathPatternConfig = { normalizeTrailingSlash: true },
+): Option.Option<RoutePathPatternMatch> => {
+  const pathParts = splitPath(pathname, config);
+  const params: Record<string, string> = {};
+
+  if (pattern.segments.length === 0 && pathParts.length === 0) {
+    return Option.some({ pattern, params });
+  }
+
+  let pathIndex = 0;
+  for (const segment of pattern.segments) {
+    switch (segment._tag) {
+      case "Static": {
+        if (pathParts[pathIndex] !== segment.value) return Option.none();
+        pathIndex++;
+        break;
+      }
+      case "Param": {
+        const part = pathParts[pathIndex];
+        if (part === undefined) return Option.none();
+        params[segment.name] = part;
+        pathIndex++;
+        break;
+      }
+      case "Wildcard": {
+        params[segment.name] = pathParts.slice(pathIndex).join("/");
+        pathIndex = pathParts.length;
+        break;
+      }
+      case "CatchAllRequired": {
+        const rest = pathParts.slice(pathIndex).join("/");
+        if (rest === "") return Option.none();
+        params[segment.name] = rest;
+        pathIndex = pathParts.length;
+        break;
+      }
+    }
+  }
+
+  return pathIndex === pathParts.length ? Option.some({ pattern, params }) : Option.none();
+};
+
+/** RoutePathPattern service. */
+export class RoutePathPattern extends Context.Service<
+  RoutePathPattern,
+  {
+    readonly compile: (
+      pattern: string,
+    ) => Effect.Effect<CompiledRoutePathPattern, InvalidRoutePathPattern>;
+    readonly compare: (
+      left: CompiledRoutePathPattern,
+      right: CompiledRoutePathPattern,
+    ) => Effect.Effect<number>;
+    readonly match: (
+      pattern: CompiledRoutePathPattern,
+      pathname: string,
+    ) => Effect.Effect<Option.Option<RoutePathPatternMatch>>;
+  }
+>()("trygg/RoutePathPattern") {
+  static readonly layer = (input: RoutePathPatternConfig): Layer.Layer<RoutePathPattern> => {
+    const config = RoutePathPatternConfigInput.make(input);
+    return Layer.succeed(RoutePathPattern, {
+      compile: Effect.fn("RoutePathPattern.compile")((pattern) =>
+        compileRoutePathPattern(pattern, config),
+      ),
+      compare: Effect.fn("RoutePathPattern.compare")((left, right) =>
+        Effect.succeed(compareCompiledRoutePathPatterns(left, right)),
+      ),
+      match: Effect.fn("RoutePathPattern.match")((pattern, pathname) =>
+        Effect.succeed(matchCompiledRoutePathPattern(pattern, pathname, config)),
+      ),
+    });
+  };
+}


### PR DESCRIPTION
## Summary

- Adds the internal `RoutePathPattern` contract for compile/compare/match path semantics.
- Moves RouteMatcher, `createMatcher`, and Outlet trie compilation onto the canonical pattern model.
- Adds focused table-driven coverage for static, param, wildcard, catch-all, root, trailing slash, and precedence behavior.

## DX impact

Before:

```ts
// Matching rules were duplicated across matching.ts and outlet.ts.
// Changing wildcard behavior required editing parsePattern/scoreRoute/linearMatch/trie code separately.
const matcher = yield* createMatcher(routes.manifest)
const match = matcher.match("/docs/api/router")
```

After:

```ts
const pattern = yield* compileRoutePathPattern("/docs/:path+")
const match = matchCompiledRoutePathPattern(pattern, "/docs/api/router")
// Option.some({ params: { path: "api/router" }, pattern })
```

Route and Outlet matching now delegate to the same compiled path-pattern semantics.

## Acceptance criteria

From #226 / #213:

- [x] A RoutePathPattern module/service exists with segment, compiled pattern, match result, invalid-pattern error, config, and service shape compatible with #213.
- [x] Table-driven tests cover static, param, wildcard `:name*`, required catch-all `:name+`, root/index, trailing slash normalization, and precedence sorting.
- [x] `RouteMatcher.make` and `RouteMatcher.test` delegate to the RoutePathPattern contract for sorting and matching.
- [x] Local duplicated `parsePattern`, `scoreRoute`, and `linearMatch` behavior is removed or reduced to adapters over RoutePathPattern.
- [x] Existing router matching and Outlet behavior remains externally unchanged.

## Weird spots or spots that need attention

- `RoutePathPattern.compile` models invalid pattern syntax, while existing router matchers treat route definitions as framework-owned/prevalidated and die on impossible invalid patterns rather than widening matcher errors.
- Outlet still keeps trie-specific traversal for production matching speed, but trie compilation now consumes the canonical compiled pattern instead of reparsing route strings.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. **#245** 👈 current
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->