### PR TITLE
feat(core): canonicalize route path interpolation

### DIFF
--- a/packages/core/src/router/__tests__/navigation-params.test.ts
+++ b/packages/core/src/router/__tests__/navigation-params.test.ts
@@ -208,10 +208,10 @@ describe("interpolateParams", () => {
     }),
   );
 
-  it.effect("should not replace non-matching params", () =>
+  it.effect("should fail clearly when required params are missing", () =>
     Effect.gen(function* () {
-      const result = yield* interpolateParams("/users/:id", { name: "test" });
-      assert.strictEqual(result, "/users/:id");
+      const result = yield* Effect.exit(interpolateParams("/users/:id", { name: "test" }));
+      assert.strictEqual(result._tag, "Failure");
     }),
   );
 

--- a/packages/core/src/router/__tests__/path-pattern.test.ts
+++ b/packages/core/src/router/__tests__/path-pattern.test.ts
@@ -1,10 +1,12 @@
 import { assert, describe, it } from "@effect/vitest";
-import { Effect, Option } from "effect";
+import { Effect, Layer, Option } from "effect";
 import {
   compileRoutePathPattern,
   compareCompiledRoutePathPatterns,
   matchCompiledRoutePathPattern,
   RoutePathPattern,
+  RoutePathInterpolation,
+  interpolateCompiledRoutePathPattern,
 } from "../path-pattern.js";
 
 const compile = (pattern: string) => compileRoutePathPattern(pattern);
@@ -93,6 +95,60 @@ describe("RoutePathPattern", () => {
         ["/docs/settings", "/docs/:id", "/docs/:path+", "/docs/:path*"],
       );
     }),
+  );
+
+  it.effect("interpolates required, wildcard, numeric, and no-param paths", () =>
+    Effect.gen(function* () {
+      const blog = yield* compile("/blog/:year/:slug");
+      const docs = yield* compile("/docs/:path*");
+      const about = yield* compile("/about");
+
+      assert.strictEqual(
+        yield* interpolateCompiledRoutePathPattern(blog, { year: 2026, slug: "trygg" }),
+        "/blog/2026/trygg",
+      );
+      assert.strictEqual(yield* interpolateCompiledRoutePathPattern(docs, {}), "/docs");
+      assert.strictEqual(
+        yield* interpolateCompiledRoutePathPattern(docs, { path: "api/router" }),
+        "/docs/api/router",
+      );
+      assert.strictEqual(yield* interpolateCompiledRoutePathPattern(about, {}), "/about");
+    }),
+  );
+
+  it.effect("fails interpolation on missing params and can reject unused params", () =>
+    Effect.gen(function* () {
+      const pattern = yield* compile("/users/:id");
+      const missing = yield* Effect.exit(interpolateCompiledRoutePathPattern(pattern, {}));
+      const unused = yield* Effect.exit(
+        interpolateCompiledRoutePathPattern(pattern, { id: "1", extra: "x" }, { rejectUnusedParams: true }),
+      );
+
+      assert.strictEqual(missing._tag, "Failure");
+      assert.strictEqual(unused._tag, "Failure");
+    }),
+  );
+
+  it.effect("exposes interpolation through the service", () =>
+    Effect.gen(function* () {
+      const patterns = yield* RoutePathPattern;
+      const interpolation = yield* RoutePathInterpolation;
+      const pattern = yield* patterns.compile("/users/:id");
+      const names = yield* interpolation.paramNames(pattern);
+      const id = yield* interpolation.paramOption({ id: 42 }, "id");
+      const path = yield* interpolation.interpolate(pattern, { id: 42 });
+
+      assert.deepStrictEqual(names, ["id"]);
+      assert.isTrue(Option.isSome(id));
+      assert.strictEqual(path, "/users/42");
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          RoutePathPattern.layer({ normalizeTrailingSlash: true }),
+          RoutePathInterpolation.layer({ rejectUnusedParams: false }),
+        ),
+      ),
+    ),
   );
 
   it.effect("exposes compile, compare, and match through the service", () =>

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -132,16 +132,25 @@ export type { ResolvedRoute, RouteMatch, RouteMatcherShape, SyncMatcher } from "
 // Route Path Pattern
 export {
   RoutePathPattern,
+  RoutePathInterpolation,
   compileRoutePathPattern,
   compareCompiledRoutePathPatterns,
   matchCompiledRoutePathPattern,
+  interpolateCompiledRoutePathPattern,
+  getPathParamOption,
   InvalidRoutePathPattern,
+  MissingRoutePathParam,
+  UnusedRoutePathParam,
+  InvalidRoutePathParamValue,
   RoutePathPatternConfigInput,
+  RoutePathInterpolationConfigInput,
 } from "./path-pattern.js";
 export type {
   RoutePathSegment,
   CompiledRoutePathPattern,
   RoutePathPatternMatch,
+  PathParamValue,
+  PathParamInput,
 } from "./path-pattern.js";
 
 // Route Builder

--- a/packages/core/src/router/link.ts
+++ b/packages/core/src/router/link.ts
@@ -222,7 +222,7 @@ function LinkImpl<Path extends RoutePath>(props: LinkProps<Path>): Element {
   const run = (): Effect.Effect<Element, never, Router> =>
     Effect.gen(function* () {
       // Build resolved path (substitute params if provided)
-      const resolvedPath = params ? yield* buildPathWithParams(to, params) : to;
+      const resolvedPath = params ? yield* buildPathWithParams(to, params).pipe(Effect.orDie) : to;
 
       // Build full href with query string
       const href = yield* buildPath(resolvedPath, queryParams);

--- a/packages/core/src/router/path-pattern.ts
+++ b/packages/core/src/router/path-pattern.ts
@@ -185,6 +185,108 @@ export const matchCompiledRoutePathPattern = (
   return pathIndex === pathParts.length ? Option.some({ pattern, params }) : Option.none();
 };
 
+export type PathParamValue = string | number;
+export type PathParamInput = Readonly<Record<string, PathParamValue>>;
+
+export class MissingRoutePathParam extends Data.TaggedError("MissingRoutePathParam")<{
+  readonly pattern: string;
+  readonly param: string;
+}> {}
+
+export class UnusedRoutePathParam extends Data.TaggedError("UnusedRoutePathParam")<{
+  readonly pattern: string;
+  readonly param: string;
+}> {}
+
+export class InvalidRoutePathParamValue extends Data.TaggedError("InvalidRoutePathParamValue")<{
+  readonly pattern: string;
+  readonly param: string;
+  readonly value: unknown;
+  readonly reason: string;
+}> {}
+
+export const RoutePathInterpolationConfigInput = Schema.Struct({
+  rejectUnusedParams: Schema.Boolean,
+});
+
+type RoutePathInterpolationConfig = typeof RoutePathInterpolationConfigInput.Type;
+
+type RoutePathInterpolationError =
+  | MissingRoutePathParam
+  | UnusedRoutePathParam
+  | InvalidRoutePathParamValue;
+
+export const getPathParamOption = (
+  params: PathParamInput,
+  key: string,
+): Option.Option<PathParamValue> => {
+  if (!Object.prototype.hasOwnProperty.call(params, key)) {
+    return Option.none();
+  }
+  const value = params[key];
+  return value === undefined ? Option.none() : Option.some(value);
+};
+
+const validateParamValue = (
+  pattern: CompiledRoutePathPattern,
+  param: string,
+  value: unknown,
+): Effect.Effect<PathParamValue, InvalidRoutePathParamValue> => {
+  if (typeof value === "string" || typeof value === "number") {
+    return Effect.succeed(value);
+  }
+  return Effect.fail(
+    new InvalidRoutePathParamValue({
+      pattern: pattern.pattern,
+      param,
+      value,
+      reason: "path params must be strings or numbers",
+    }),
+  );
+};
+
+export const interpolateCompiledRoutePathPattern = (
+  pattern: CompiledRoutePathPattern,
+  params: PathParamInput,
+  config: RoutePathInterpolationConfig = { rejectUnusedParams: false },
+): Effect.Effect<string, RoutePathInterpolationError> =>
+  Effect.gen(function* () {
+    if (config.rejectUnusedParams) {
+      for (const key of Object.keys(params)) {
+        if (!pattern.paramNames.includes(key)) {
+          return yield* new UnusedRoutePathParam({ pattern: pattern.pattern, param: key });
+        }
+      }
+    }
+
+    const parts: Array<string> = [];
+    for (const segment of pattern.segments) {
+      if (segment._tag === "Static") {
+        parts.push(segment.value);
+        continue;
+      }
+
+      const option = getPathParamOption(params, segment.name);
+      if (Option.isNone(option)) {
+        if (segment._tag === "Wildcard") {
+          continue;
+        }
+        return yield* new MissingRoutePathParam({ pattern: pattern.pattern, param: segment.name });
+      }
+
+      const value = yield* validateParamValue(pattern, segment.name, option.value);
+      const text = String(value);
+      if (segment._tag !== "Wildcard" && text === "") {
+        return yield* new MissingRoutePathParam({ pattern: pattern.pattern, param: segment.name });
+      }
+      if (text !== "") {
+        parts.push(...text.split("/").filter(Boolean));
+      }
+    }
+
+    return `/${parts.join("/")}`;
+  });
+
 /** RoutePathPattern service. */
 export class RoutePathPattern extends Context.Service<
   RoutePathPattern,
@@ -213,6 +315,38 @@ export class RoutePathPattern extends Context.Service<
       ),
       match: Effect.fn("RoutePathPattern.match")((pattern, pathname) =>
         Effect.succeed(matchCompiledRoutePathPattern(pattern, pathname, config)),
+      ),
+    });
+  };
+}
+
+export class RoutePathInterpolation extends Context.Service<
+  RoutePathInterpolation,
+  {
+    readonly paramNames: (
+      pattern: CompiledRoutePathPattern,
+    ) => Effect.Effect<ReadonlyArray<string>>;
+    readonly interpolate: (
+      pattern: CompiledRoutePathPattern,
+      params: PathParamInput,
+    ) => Effect.Effect<string, RoutePathInterpolationError>;
+    readonly paramOption: (
+      params: PathParamInput,
+      key: string,
+    ) => Effect.Effect<Option.Option<PathParamValue>>;
+  }
+>()("trygg/RoutePathInterpolation") {
+  static readonly layer = (input: RoutePathInterpolationConfig): Layer.Layer<RoutePathInterpolation> => {
+    const config = RoutePathInterpolationConfigInput.make(input);
+    return Layer.succeed(RoutePathInterpolation, {
+      paramNames: Effect.fn("RoutePathInterpolation.paramNames")((pattern) =>
+        Effect.succeed(pattern.paramNames),
+      ),
+      interpolate: Effect.fn("RoutePathInterpolation.interpolate")((pattern, params) =>
+        interpolateCompiledRoutePathPattern(pattern, params, config),
+      ),
+      paramOption: Effect.fn("RoutePathInterpolation.paramOption")((params, key) =>
+        Effect.succeed(getPathParamOption(params, key)),
       ),
     });
   };

--- a/packages/core/src/router/service.ts
+++ b/packages/core/src/router/service.ts
@@ -53,6 +53,19 @@ const ScrollState = Schema.Struct({ _scrollKey: Schema.String });
 /** @internal */
 const decodeScrollState = Schema.decodeUnknownOption(ScrollState);
 
+const interpolateNavigationPath = (
+  targetPath: string,
+  params: Record<string, string | number>,
+): Effect.Effect<string, NavigationError> =>
+  interpolateParams(targetPath, params).pipe(
+    Effect.mapError((cause) => new NavigationError({ operation: "interpolateParams", cause })),
+  );
+
+const interpolateActivePath = (
+  targetPath: string,
+  params: Record<string, string | number>,
+): Effect.Effect<string> => interpolateParams(targetPath, params).pipe(Effect.orDie);
+
 // F-001: Viewport prefetch constants from framework research
 /** IntersectionObserver threshold - 10% visible triggers prefetch */
 const INTERSECTION_THRESHOLD = 0.1;
@@ -780,7 +793,7 @@ export const browserLayer: Layer.Layer<
 
         // Interpolate params into path pattern if provided
         const resolvedPath = options?.params
-          ? yield* interpolateParams(targetPath, options.params)
+          ? yield* interpolateNavigationPath(targetPath, options.params)
           : targetPath;
 
         const current = yield* Signal.get(currentSignal);
@@ -910,7 +923,7 @@ export const browserLayer: Layer.Layer<
       isActive: (targetPath: string, options?: IsActiveOptions) =>
         Effect.gen(function* () {
           const resolvedPath = options?.params
-            ? yield* interpolateParams(targetPath, options.params)
+            ? yield* interpolateActivePath(targetPath, options.params)
             : targetPath;
           const matcher = options?.exact
             ? (route: Route) => route.path === resolvedPath
@@ -1043,7 +1056,7 @@ export const testLayer = (
 
           // Interpolate params into path pattern if provided
           const resolvedPath = options?.params
-            ? yield* interpolateParams(targetPath, options.params)
+            ? yield* interpolateNavigationPath(targetPath, options.params)
             : targetPath;
 
           const current = yield* Signal.get(currentSignal);
@@ -1164,7 +1177,7 @@ export const testLayer = (
         isActive: (targetPath: string, options?: IsActiveOptions) =>
           Effect.gen(function* () {
             const resolvedPath = options?.params
-              ? yield* interpolateParams(targetPath, options.params)
+              ? yield* interpolateActivePath(targetPath, options.params)
               : targetPath;
             const matcher = options?.exact
               ? (route: Route) => route.path === resolvedPath

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -25,6 +25,14 @@ import { Component } from "../primitives/component.js";
 import type { Signal } from "../primitives/signal.js";
 import type { Element } from "../primitives/element.js";
 import type { ScrollStrategyType } from "./scroll-strategy.js";
+import {
+  compileRoutePathPattern,
+  interpolateCompiledRoutePathPattern,
+  type InvalidRoutePathPattern,
+  type InvalidRoutePathParamValue,
+  type MissingRoutePathParam,
+  type UnusedRoutePathParam,
+} from "./path-pattern.js";
 
 // ==========================================
 // Errors
@@ -336,16 +344,16 @@ export type TypeSafeLinkProps<Path extends string> =
 export const buildPathWithParams = <Path extends string>(
   path: Path,
   params: RouteParamsFor<Path>,
-): Effect.Effect<string> =>
-  Effect.sync(() => {
-    let result: string = path;
-    for (const key of Object.keys(params)) {
-      const value = (params as Record<string, string | number>)[key];
-      if (value !== undefined) {
-        result = result.replace(`:${key}`, String(value));
-      }
-    }
-    return result;
+): Effect.Effect<
+  string,
+  | InvalidRoutePathPattern
+  | MissingRoutePathParam
+  | UnusedRoutePathParam
+  | InvalidRoutePathParamValue
+> =>
+  Effect.gen(function* () {
+    const pattern = yield* compileRoutePathPattern(path);
+    return yield* interpolateCompiledRoutePathPattern(pattern, params);
   });
 
 /**
@@ -363,16 +371,16 @@ export const buildPathWithParams = <Path extends string>(
 export const interpolateParams = (
   path: string,
   params: Record<string, string | number>,
-): Effect.Effect<string> =>
-  Effect.sync(() => {
-    let result = path;
-    for (const key of Object.keys(params)) {
-      const value = params[key];
-      if (value !== undefined) {
-        result = result.replace(`:${key}`, String(value));
-      }
-    }
-    return result;
+): Effect.Effect<
+  string,
+  | InvalidRoutePathPattern
+  | MissingRoutePathParam
+  | UnusedRoutePathParam
+  | InvalidRoutePathParamValue
+> =>
+  Effect.gen(function* () {
+    const pattern = yield* compileRoutePathPattern(path);
+    return yield* interpolateCompiledRoutePathPattern(pattern, params);
   });
 
 // ==========================================


### PR DESCRIPTION
## Summary

- Adds `RoutePathInterpolation` on top of the canonical compiled pattern model.
- Routes `buildPathWithParams`, `interpolateParams`, Link href creation, and Router navigation through canonical interpolation.
- Adds tests for missing params, numeric params, wildcard interpolation, unused-param policy, no-param paths, and service behavior.

## DX impact

Before:

```ts
yield* interpolateParams("/users/:id", { name: "Ada" })
// "/users/:id"  (silently left the required token in the path)
```

After:

```ts
yield* interpolateParams("/users/:id", { name: "Ada" })
// fails with MissingRoutePathParam({ pattern: "/users/:id", param: "id" })

const pattern = yield* compileRoutePathPattern("/docs/:path*")
yield* interpolateCompiledRoutePathPattern(pattern, {})
// "/docs"
```

## Acceptance criteria

From #227 / #214:

- [x] RoutePathInterpolation exists with `paramNames`, `interpolate`, and `paramOption` behavior compatible with #214.
- [x] `buildPathWithParams` and `interpolateParams` delegate to canonical interpolation while preserving their public call sites.
- [x] Link and Router navigation use the canonical interpolation path when params are supplied.
- [x] Tests cover missing params, numeric params, wildcard params, unused params policy, no-param paths, and generated route type agreement.
- [x] Existing navigation params tests continue to pass with no app-facing API churn beyond typed domain failures required by #214.

## Weird spots or spots that need attention

- `RouterService.navigate` keeps its existing `NavigationError` public error contract and wraps interpolation failures as `NavigationError({ operation: "interpolateParams", cause })`; the lower-level utilities expose the typed interpolation errors directly.
- Link rendering and `isActive` fail loudly on invalid runtime params because those surfaces are intended to be compile-time checked and currently have `never` error contracts.
- Unused params default to ignored to preserve existing navigation behavior, but the interpolation contract supports explicit `rejectUnusedParams` for tests and stricter internal callers.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. **#246** 👈 current
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->