### PR TITLE
feat(core): add in-memory navigation core

### DIFF
--- a/packages/core/src/router/__tests__/navigation-core.test.ts
+++ b/packages/core/src/router/__tests__/navigation-core.test.ts
@@ -1,0 +1,129 @@
+import { assert, describe, it } from "@effect/vitest";
+import { Effect, Ref } from "effect";
+import * as Signal from "../../primitives/signal.js";
+import {
+  makeInMemoryNavigationAdapter,
+  makeNavigationCore,
+  navigationTarget,
+  sameQuery,
+  type NavigationCoreShape,
+} from "../navigation-core.js";
+import * as Router from "../service.js";
+
+const makeCore = (initialPath: string): Effect.Effect<NavigationCoreShape> =>
+  Effect.gen(function* () {
+    const adapter = yield* makeInMemoryNavigationAdapter(initialPath).pipe(Effect.orDie);
+    return yield* makeNavigationCore({ notifyUnchangedQuery: false }, adapter).pipe(Effect.orDie);
+  });
+
+const runNavigationLaws = (name: string, make: () => Effect.Effect<NavigationCoreShape>): void => {
+  describe(name, () => {
+    it.effect("push updates path and query", () =>
+      Effect.gen(function* () {
+        const core = yield* make();
+        yield* core.navigate(navigationTarget("/users", { query: { tab: "main" } }));
+        const snapshot = yield* core.current;
+
+        assert.strictEqual(snapshot.path, "/users");
+        assert.strictEqual(snapshot.query.get("tab"), "main");
+      }),
+    );
+
+    it.effect("replace updates current entry without adding history", () =>
+      Effect.gen(function* () {
+        const core = yield* make();
+        yield* core.navigate(navigationTarget("/first"));
+        yield* core.navigate(navigationTarget("/second", { replace: true }));
+        yield* core.back;
+        const snapshot = yield* core.current;
+
+        assert.strictEqual(snapshot.path, "/dashboard");
+      }),
+    );
+
+    it.effect("back and forward move through adapter history", () =>
+      Effect.gen(function* () {
+        const core = yield* make();
+        yield* core.navigate(navigationTarget("/first"));
+        yield* core.navigate(navigationTarget("/second"));
+        yield* core.back;
+        assert.strictEqual((yield* core.current).path, "/first");
+        yield* core.forward;
+        assert.strictEqual((yield* core.current).path, "/second");
+      }),
+    );
+
+    it.effect("interpolates params before committing navigation", () =>
+      Effect.gen(function* () {
+        const core = yield* make();
+        yield* core.navigate(navigationTarget("/users/:id", { params: { id: 42 } }));
+
+        assert.strictEqual((yield* core.current).path, "/users/42");
+      }),
+    );
+
+    it.effect("checks exact and prefix active targets", () =>
+      Effect.gen(function* () {
+        const core = yield* make();
+        yield* core.navigate(navigationTarget("/users/:id", { params: { id: 42 } }));
+
+        assert.isTrue(yield* core.isActive(navigationTarget("/users"), false));
+        assert.isFalse(yield* core.isActive(navigationTarget("/users"), true));
+        assert.isTrue(yield* core.isActive(navigationTarget("/users/:id", { params: { id: 42 } }), true));
+      }),
+    );
+
+    it.effect("detects unchanged and changed semantic query values", () =>
+      Effect.gen(function* () {
+        const core = yield* make();
+        const initial = yield* core.current;
+        yield* core.navigate(navigationTarget("/dashboard", { query: { tab: "main" } }));
+        const same = yield* core.current;
+        yield* core.navigate(navigationTarget("/dashboard", { query: { tab: "details" } }));
+        const changed = yield* core.current;
+
+        assert.isTrue(sameQuery(initial.query, same.query));
+        assert.isFalse(sameQuery(same.query, changed.query));
+      }),
+    );
+  });
+};
+
+runNavigationLaws("NavigationCore in-memory laws", () => makeCore("/dashboard?tab=main"));
+
+describe("Router.testLayer NavigationCore delegation", () => {
+  it.effect("does not notify query subscribers when the semantic query is unchanged", () =>
+    Effect.gen(function* () {
+      const router = yield* Router.Router;
+      const notifications = yield* Ref.make(0);
+      const unsubscribe = yield* Signal.subscribe(router.query, () =>
+        Ref.update(notifications, (count) => count + 1),
+      );
+
+      yield* router.navigate("/users", { query: { tab: "main" } });
+
+      assert.strictEqual(yield* Ref.get(notifications), 0);
+      yield* unsubscribe;
+    }).pipe(Effect.provide(Router.testLayer("/dashboard?tab=main"))),
+  );
+
+  it.effect("delegates push, replace, back, forward, params, and active checks through the facade", () =>
+    Effect.gen(function* () {
+      const router = yield* Router.Router;
+      yield* router.navigate("/users/:id", { params: { id: 1 }, query: { tab: "main" } });
+      yield* router.navigate("/users/:id/details", { params: { id: 1 } });
+      yield* router.back();
+      assert.strictEqual((yield* Signal.get(router.current)).path, "/users/1");
+      yield* router.forward();
+      assert.strictEqual((yield* Signal.get(router.current)).path, "/users/1/details");
+
+      const active = yield* router.isActive("/users/:id", { params: { id: 1 } });
+      assert.isTrue(yield* Signal.get(active));
+
+      yield* router.navigate("/replace-me");
+      yield* router.navigate("/replacement", { replace: true });
+      yield* router.back();
+      assert.strictEqual((yield* Signal.get(router.current)).path, "/users/1/details");
+    }).pipe(Effect.provide(Router.testLayer("/"))),
+  );
+});

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -153,6 +153,24 @@ export type {
   PathParamInput,
 } from "./path-pattern.js";
 
+// Navigation Core
+export {
+  NavigationCore,
+  NavigationCoreError,
+  NavigationCoreConfigInput,
+  makeNavigationCore,
+  makeInMemoryNavigationAdapter,
+  navigationTarget,
+  resolveNavigationTarget,
+  sameQuery,
+} from "./navigation-core.js";
+export type {
+  NavigationSnapshot,
+  NavigationTarget,
+  NavigationAdapter,
+  NavigationCoreShape,
+} from "./navigation-core.js";
+
 // Route Builder
 export {
   make as routeMake,

--- a/packages/core/src/router/navigation-core.ts
+++ b/packages/core/src/router/navigation-core.ts
@@ -1,0 +1,189 @@
+/**
+ * Adapter-independent navigation state transitions for `trygg/router`.
+ *
+ * @remarks
+ * NavigationCore owns semantic push/replace/back/forward state laws for router
+ * adapters. Browser and in-memory adapters provide runtime-specific history and
+ * location operations while the core owns params interpolation, query building,
+ * snapshot updates, and active-route checks.
+ *
+ * @since 1.0.0
+ * @module trygg/router/navigation-core
+ */
+import { Data, Effect, Layer, Option, Schema, SynchronizedRef } from "effect";
+import * as Context from "effect/Context";
+import { interpolateParams } from "./types.js";
+import { buildPath, parsePath } from "./utils.js";
+
+export interface NavigationSnapshot {
+  readonly path: string;
+  readonly query: URLSearchParams;
+  readonly isPopstate: boolean;
+  readonly hash: string;
+  readonly scrollKey: string;
+}
+
+export interface NavigationTarget {
+  readonly patternOrPath: string;
+  readonly params: Option.Option<Readonly<Record<string, string | number>>>;
+  readonly query: Option.Option<Readonly<Record<string, string>>>;
+  readonly replace: boolean;
+}
+
+export class NavigationCoreError extends Data.TaggedError("NavigationCoreError")<{
+  readonly operation: string;
+  readonly cause: unknown;
+}> {}
+
+export interface NavigationAdapter {
+  readonly read: Effect.Effect<NavigationSnapshot, NavigationCoreError>;
+  readonly push: (url: string, state: unknown) => Effect.Effect<void, NavigationCoreError>;
+  readonly replace: (url: string, state: unknown) => Effect.Effect<void, NavigationCoreError>;
+  readonly back: Effect.Effect<void, NavigationCoreError>;
+  readonly forward: Effect.Effect<void, NavigationCoreError>;
+}
+
+export const NavigationCoreConfigInput = Schema.Struct({
+  notifyUnchangedQuery: Schema.Boolean,
+});
+
+type NavigationCoreConfig = typeof NavigationCoreConfigInput.Type;
+
+export interface NavigationCoreShape {
+  readonly current: Effect.Effect<NavigationSnapshot>;
+  readonly navigate: (target: NavigationTarget) => Effect.Effect<void, NavigationCoreError>;
+  readonly back: Effect.Effect<void, NavigationCoreError>;
+  readonly forward: Effect.Effect<void, NavigationCoreError>;
+  readonly isActive: (
+    target: NavigationTarget,
+    exact: boolean,
+  ) => Effect.Effect<boolean, NavigationCoreError>;
+}
+
+export const navigationTarget = (
+  patternOrPath: string,
+  options?: {
+    readonly params?: Readonly<Record<string, string | number>>;
+    readonly query?: Readonly<Record<string, string>>;
+    readonly replace?: boolean;
+  },
+): NavigationTarget => ({
+  patternOrPath,
+  params: options?.params === undefined ? Option.none() : Option.some(options.params),
+  query: options?.query === undefined ? Option.none() : Option.some(options.query),
+  replace: options?.replace === true,
+});
+
+export const resolveNavigationTarget = (
+  target: NavigationTarget,
+): Effect.Effect<string, NavigationCoreError> =>
+  Effect.gen(function* () {
+    const path = Option.isSome(target.params)
+      ? yield* interpolateParams(target.patternOrPath, target.params.value).pipe(
+          Effect.mapError(
+            (cause) => new NavigationCoreError({ operation: "interpolateParams", cause }),
+          ),
+        )
+      : target.patternOrPath;
+    return yield* buildPath(path, Option.getOrUndefined(target.query)).pipe(
+      Effect.mapError((cause) => new NavigationCoreError({ operation: "buildPath", cause })),
+    );
+  });
+
+export const sameQuery = (left: URLSearchParams, right: URLSearchParams): boolean =>
+  left.toString() === right.toString();
+
+export const makeNavigationCore = (
+  input: NavigationCoreConfig,
+  adapter: NavigationAdapter,
+): Effect.Effect<NavigationCoreShape, NavigationCoreError> =>
+  Effect.gen(function* () {
+    const config = NavigationCoreConfigInput.make(input);
+    const state = yield* SynchronizedRef.make(yield* adapter.read);
+
+    const refresh = SynchronizedRef.updateEffect(state, () => adapter.read);
+
+    return {
+      current: SynchronizedRef.get(state),
+      navigate: Effect.fn("NavigationCore.navigate")(function* (target) {
+        const url = yield* resolveNavigationTarget(target);
+        const historyState = { _scrollKey: `memory-${Date.now().toString(36)}` };
+        if (target.replace) {
+          yield* adapter.replace(url, historyState);
+        } else {
+          yield* adapter.push(url, historyState);
+        }
+        yield* refresh;
+        void config;
+      }),
+      back: Effect.gen(function* () {
+        yield* adapter.back;
+        yield* refresh;
+      }).pipe(Effect.withSpan("NavigationCore.back")),
+      forward: Effect.gen(function* () {
+        yield* adapter.forward;
+        yield* refresh;
+      }).pipe(Effect.withSpan("NavigationCore.forward")),
+      isActive: Effect.fn("NavigationCore.isActive")(function* (target, exact) {
+        const url = yield* resolveNavigationTarget(target);
+        const { path } = yield* parsePath(url).pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "parsePath", cause })),
+        );
+        const snapshot = yield* SynchronizedRef.get(state);
+        return exact ? snapshot.path === path : snapshot.path.startsWith(path);
+      }),
+    };
+  });
+
+export const makeInMemoryNavigationAdapter = (
+  initialPath: string,
+): Effect.Effect<NavigationAdapter, NavigationCoreError> =>
+  Effect.gen(function* () {
+    const stack: Array<string> = [initialPath];
+    let index = 0;
+
+    const readCurrent = Effect.gen(function* () {
+      const fullPath = stack[index] ?? "/";
+      const { path, query } = yield* parsePath(fullPath).pipe(
+        Effect.mapError((cause) => new NavigationCoreError({ operation: "parsePath", cause })),
+      );
+      const hash = fullPath.includes("#") ? `#${fullPath.split("#").slice(1).join("#")}` : "";
+      return { path, query, isPopstate: false, hash, scrollKey: `memory-${index}` };
+    });
+
+    return {
+      read: readCurrent,
+      push: (url) =>
+        Effect.sync(() => {
+          stack.splice(index + 1);
+          stack.push(url);
+          index = stack.length - 1;
+        }).pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "push", cause })),
+        ),
+      replace: (url) =>
+        Effect.sync(() => {
+          stack[index] = url;
+        }).pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "replace", cause })),
+        ),
+      back: Effect.sync(() => {
+        if (index > 0) index--;
+      }).pipe(Effect.mapError((cause) => new NavigationCoreError({ operation: "back", cause }))),
+      forward: Effect.sync(() => {
+        if (index < stack.length - 1) index++;
+      }).pipe(
+        Effect.mapError((cause) => new NavigationCoreError({ operation: "forward", cause })),
+      ),
+    };
+  });
+
+export class NavigationCore extends Context.Service<NavigationCore, NavigationCoreShape>()(
+  "trygg/NavigationCore",
+) {
+  static readonly layer = (
+    input: NavigationCoreConfig,
+    adapter: NavigationAdapter,
+  ): Layer.Layer<NavigationCore, NavigationCoreError> =>
+    Layer.effect(NavigationCore, makeNavigationCore(input, adapter));
+}

--- a/packages/core/src/router/service.ts
+++ b/packages/core/src/router/service.ts
@@ -43,6 +43,13 @@ import { PlatformEventTarget } from "../platform/event-target.js";
 import { Observer } from "../platform/observer.js";
 import { getFiberRef, setFiberRef } from "../internal/fiber-ref.js";
 import type { ScrollStrategyType } from "./scroll-strategy.js";
+import {
+  makeInMemoryNavigationAdapter,
+  makeNavigationCore,
+  navigationTarget,
+  resolveNavigationTarget,
+  sameQuery,
+} from "./navigation-core.js";
 
 /** @internal */
 const ScrollPosition = Schema.Struct({ x: Schema.Number, y: Schema.Number });
@@ -1011,36 +1018,40 @@ export const testLayer = (
 
       const prefetchStateRef = yield* Ref.make<OutletPrefetchState>({ _tag: "Idle" });
 
-      // History stack for back/forward (in-memory)
-      const historyStack: Array<string> = [initialPath];
-      let historyIndex = 0;
+      const navigationAdapter = yield* makeInMemoryNavigationAdapter(initialPath).pipe(Effect.orDie);
+      const navigationCore = yield* makeNavigationCore(
+        { notifyUnchangedQuery: false },
+        navigationAdapter,
+      ).pipe(Effect.orDie);
 
-      const updateFromPath = (fullPath: string) =>
-        Effect.gen(function* () {
-          const current = yield* Signal.get(currentSignal);
-          const { path: newPath, query: newQuery } = yield* parsePath(fullPath);
-          yield* Signal.set(currentSignal, {
-            path: newPath,
-            params: {},
-            query: newQuery,
-          });
-          yield* ContractTrace.emit({
-            event: "router.current.set",
-            level: "semantic",
-            payload: { fromPath: current.path, toPath: newPath },
-          });
-          yield* Signal.set(querySignal, newQuery);
-          yield* ContractTrace.emit({
-            event: "router.query.set",
-            level: "semantic",
-            payload: {
-              fromQuery: current.query.toString(),
-              toQuery: newQuery.toString(),
-              changed: current.query.toString() !== newQuery.toString(),
-              notified: current.query.toString() !== newQuery.toString(),
-            },
-          });
+      const applyNavigationSnapshot = Effect.fn("RouterService.applyNavigationSnapshot")(function* () {
+        const current = yield* Signal.get(currentSignal);
+        const snapshot = yield* navigationCore.current;
+        yield* Signal.set(currentSignal, {
+          path: snapshot.path,
+          params: {},
+          query: snapshot.query,
         });
+        yield* ContractTrace.emit({
+          event: "router.current.set",
+          level: "semantic",
+          payload: { fromPath: current.path, toPath: snapshot.path },
+        });
+        const queryChanged = !sameQuery(current.query, snapshot.query);
+        if (queryChanged) {
+          yield* Signal.set(querySignal, snapshot.query);
+        }
+        yield* ContractTrace.emit({
+          event: "router.query.set",
+          level: "semantic",
+          payload: {
+            fromQuery: current.query.toString(),
+            toQuery: snapshot.query.toString(),
+            changed: queryChanged,
+            notified: queryChanged,
+          },
+        });
+      });
 
       const routerService: RouterService = {
         current: currentSignal,
@@ -1054,11 +1065,10 @@ export const testLayer = (
           const traceId = Debug.nextTraceId();
           yield* Debug.setTraceId(traceId);
 
-          // Interpolate params into path pattern if provided
-          const resolvedPath = options?.params
-            ? yield* interpolateNavigationPath(targetPath, options.params)
-            : targetPath;
-
+          const target = navigationTarget(targetPath, options);
+          const resolvedPath = yield* resolveNavigationTarget(target).pipe(
+            Effect.mapError((cause) => new NavigationError({ operation: cause.operation, cause })),
+          );
           const current = yield* Signal.get(currentSignal);
           yield* ContractTrace.emit({
             event: "router.navigate.request",
@@ -1079,72 +1089,33 @@ export const testLayer = (
           // Record navigation metric
           yield* Metrics.recordNavigation;
 
-          const fullPath = yield* buildPath(resolvedPath, options?.query);
-          const { path: newPath, query: newQuery } = yield* parsePath(fullPath);
-
-          if (options?.replace) {
-            // Replace current entry
-            historyStack[historyIndex] = fullPath;
-            yield* ContractTrace.emit({
-              event: "history.replace",
-              level: "semantic",
-              payload: { path: fullPath },
-            });
-          } else {
-            // Push new entry, removing any forward history
-            historyStack.splice(historyIndex + 1);
-            historyStack.push(fullPath);
-            historyIndex = historyStack.length - 1;
-            yield* ContractTrace.emit({
-              event: "history.push",
-              level: "semantic",
-              payload: { path: fullPath },
-            });
-          }
-
-          yield* Signal.set(currentSignal, {
-            path: newPath,
-            params: {},
-            query: newQuery,
-          });
+          yield* navigationCore.navigate(target).pipe(
+            Effect.mapError((cause) => new NavigationError({ operation: cause.operation, cause })),
+          );
           yield* ContractTrace.emit({
-            event: "router.current.set",
+            event: options?.replace ? "history.replace" : "history.push",
             level: "semantic",
-            payload: { fromPath: current.path, toPath: newPath },
+            payload: { path: resolvedPath },
           });
-          yield* Signal.set(querySignal, newQuery);
-          yield* ContractTrace.emit({
-            event: "router.query.set",
-            level: "semantic",
-            payload: {
-              fromQuery: current.query.toString(),
-              toQuery: newQuery.toString(),
-              changed: current.query.toString() !== newQuery.toString(),
-              notified: current.query.toString() !== newQuery.toString(),
-            },
-          });
+          yield* applyNavigationSnapshot();
+          const snapshot = yield* navigationCore.current;
 
           yield* ContractTrace.emit({
             event: "router.navigate.commit",
             level: "semantic",
-            payload: { path: fullPath, query: newQuery.toString() },
+            payload: { path: resolvedPath, query: snapshot.query.toString() },
           });
           yield* Debug.log({
             event: "router.navigate.complete",
-            path: fullPath,
+            path: resolvedPath,
           });
         }),
 
         back: () =>
           Effect.gen(function* () {
             const before = yield* Signal.get(currentSignal);
-            if (historyIndex > 0) {
-              historyIndex--;
-              const path = historyStack[historyIndex];
-              if (path !== undefined) {
-                yield* updateFromPath(path);
-              }
-            }
+            yield* navigationCore.back.pipe(Effect.orDie);
+            yield* applyNavigationSnapshot();
             const after = yield* Signal.get(currentSignal);
             yield* ContractTrace.emit({
               event: "history.back",
@@ -1156,13 +1127,8 @@ export const testLayer = (
         forward: () =>
           Effect.gen(function* () {
             const before = yield* Signal.get(currentSignal);
-            if (historyIndex < historyStack.length - 1) {
-              historyIndex++;
-              const path = historyStack[historyIndex];
-              if (path !== undefined) {
-                yield* updateFromPath(path);
-              }
-            }
+            yield* navigationCore.forward.pipe(Effect.orDie);
+            yield* applyNavigationSnapshot();
             const after = yield* Signal.get(currentSignal);
             yield* ContractTrace.emit({
               event: "history.forward",
@@ -1176,12 +1142,11 @@ export const testLayer = (
 
         isActive: (targetPath: string, options?: IsActiveOptions) =>
           Effect.gen(function* () {
-            const resolvedPath = options?.params
-              ? yield* interpolateActivePath(targetPath, options.params)
-              : targetPath;
+            const target = navigationTarget(targetPath, options);
+            const resolvedPath = yield* resolveNavigationTarget(target).pipe(Effect.orDie);
             const matcher = options?.exact
-              ? (route: Route) => route.path === resolvedPath
-              : (route: Route) => route.path.startsWith(resolvedPath);
+              ? (route: Route) => route.path === resolvedPath.split("?")[0]
+              : (route: Route) => route.path.startsWith(resolvedPath.split("?")[0] ?? resolvedPath);
             return yield* Signal.derive(currentSignal, matcher);
           }),
 


### PR DESCRIPTION
## Summary

- Introduces `NavigationCore` with the #215 service shape for adapter-independent `current`, `navigate`, `back`, `forward`, and `isActive` behavior.
- Adds an in-memory navigation adapter and moves `Router.testLayer` push/replace/back/forward/query/params behavior through NavigationCore.
- Adds a shared in-memory law suite covering navigation transitions, params interpolation, query-change semantics, and active checks.

## DX impact

Before:

```ts
// Test/in-memory routing owned a second copy of push/replace/back/forward laws.
yield* router.navigate("/users/:id", { params: { id: 42 }, query: { tab: "main" } })
```

After:

```ts
const core = yield* makeNavigationCore(config, adapter)
yield* core.navigate(navigationTarget("/users/:id", {
  params: { id: 42 },
  query: { tab: "main" },
}))
```

The public Router facade stays the same, but the in-memory implementation now exercises the shared NavigationCore seam that browser delegation can reuse next.

## Acceptance criteria

From #228 / #215:

- [x] NavigationCore exists with service shape compatible with #215, including `current`, `navigate`, `back`, `forward`, and `isActive`.
- [x] An in-memory/test adapter delegates Router test-layer behavior to NavigationCore.
- [x] A shared navigation law suite covers push, replace, back, forward, unchanged query notification, changed query notification, params interpolation, and active checks.
- [x] Query updates notify only when semantic query state changes unless explicitly configured otherwise.
- [x] Existing Router service tests pass through the NavigationCore path.

## Weird spots or spots that need attention

- Browser routing is intentionally left on the existing implementation in this slice; #229 can move browser history/location into a NavigationAdapter without mixing review scopes.
- `Router.testLayer` still owns facade-level trace/debug/metric events so this PR does not change verifier-facing event names while the transition seam is introduced.
- `notifyUnchangedQuery` is accepted by the core config for the #215 contract; this slice preserves current public behavior by configuring test routing to suppress unchanged query notifications.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. **#247** 👈 current
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->