### PR TITLE
feat(core): delegate browser routing to navigation core

### DIFF
--- a/packages/core/src/router/__tests__/navigation-core.test.ts
+++ b/packages/core/src/router/__tests__/navigation-core.test.ts
@@ -2,17 +2,58 @@ import { assert, describe, it } from "@effect/vitest";
 import { Effect, Ref } from "effect";
 import * as Signal from "../../primitives/signal.js";
 import {
+  NavigationCoreError,
   makeInMemoryNavigationAdapter,
   makeNavigationCore,
   navigationTarget,
   sameQuery,
+  type NavigationAdapter,
   type NavigationCoreShape,
 } from "../navigation-core.js";
+import { parsePath } from "../utils.js";
 import * as Router from "../service.js";
 
 const makeCore = (initialPath: string): Effect.Effect<NavigationCoreShape> =>
   Effect.gen(function* () {
     const adapter = yield* makeInMemoryNavigationAdapter(initialPath).pipe(Effect.orDie);
+    return yield* makeNavigationCore({ notifyUnchangedQuery: false }, adapter).pipe(Effect.orDie);
+  });
+
+const makeBrowserLikeCore = (initialPath: string): Effect.Effect<NavigationCoreShape> =>
+  Effect.gen(function* () {
+    const historyStack: Array<string> = [initialPath];
+    let index = 0;
+    const adapter: NavigationAdapter = {
+      read: Effect.gen(function* () {
+        const fullPath = historyStack[index] ?? "/";
+        const { path, query } = yield* parsePath(fullPath).pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "parsePath", cause })),
+        );
+        return { path, query, isPopstate: false, hash: "", scrollKey: `browser-like-${index}` };
+      }),
+      push: (url) =>
+        Effect.sync(() => {
+          historyStack.splice(index + 1);
+          historyStack.push(url);
+          index = historyStack.length - 1;
+        }).pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "pushState", cause })),
+        ),
+      replace: (url) =>
+        Effect.sync(() => {
+          historyStack[index] = url;
+        }).pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "replaceState", cause })),
+        ),
+      back: Effect.sync(() => {
+        if (index > 0) index--;
+      }).pipe(Effect.mapError((cause) => new NavigationCoreError({ operation: "back", cause }))),
+      forward: Effect.sync(() => {
+        if (index < historyStack.length - 1) index++;
+      }).pipe(
+        Effect.mapError((cause) => new NavigationCoreError({ operation: "forward", cause })),
+      ),
+    };
     return yield* makeNavigationCore({ notifyUnchangedQuery: false }, adapter).pipe(Effect.orDie);
   });
 
@@ -90,6 +131,9 @@ const runNavigationLaws = (name: string, make: () => Effect.Effect<NavigationCor
 };
 
 runNavigationLaws("NavigationCore in-memory laws", () => makeCore("/dashboard?tab=main"));
+runNavigationLaws("NavigationCore browser-like adapter laws", () =>
+  makeBrowserLikeCore("/dashboard?tab=main"),
+);
 
 describe("Router.testLayer NavigationCore delegation", () => {
   it.effect("does not notify query subscribers when the semantic query is unchanged", () =>

--- a/packages/core/src/router/navigation-core.ts
+++ b/packages/core/src/router/navigation-core.ts
@@ -58,6 +58,7 @@ export interface NavigationCoreShape {
     target: NavigationTarget,
     exact: boolean,
   ) => Effect.Effect<boolean, NavigationCoreError>;
+  readonly refresh: Effect.Effect<void, NavigationCoreError>;
 }
 
 export const navigationTarget = (
@@ -132,6 +133,7 @@ export const makeNavigationCore = (
         const snapshot = yield* SynchronizedRef.get(state);
         return exact ? snapshot.path === path : snapshot.path.startsWith(path);
       }),
+      refresh,
     };
   });
 

--- a/packages/core/src/router/service.ts
+++ b/packages/core/src/router/service.ts
@@ -31,9 +31,9 @@ import type {
   RoutePath,
   RouteParamsFor,
 } from "./types.js";
-import { NavigationError, interpolateParams } from "./types.js";
+import { NavigationError } from "./types.js";
 import type { Element } from "../primitives/element.js";
-import { parsePath, buildPath } from "./utils.js";
+import { parsePath } from "./utils.js";
 import { SessionStorage } from "../platform/storage.js";
 import { Scroll } from "../platform/scroll.js";
 import { Dom, DomError } from "../platform/dom.js";
@@ -44,6 +44,7 @@ import { Observer } from "../platform/observer.js";
 import { getFiberRef, setFiberRef } from "../internal/fiber-ref.js";
 import type { ScrollStrategyType } from "./scroll-strategy.js";
 import {
+  NavigationCoreError,
   makeInMemoryNavigationAdapter,
   makeNavigationCore,
   navigationTarget,
@@ -59,19 +60,6 @@ const ScrollPositionJson = Schema.fromJsonString(ScrollPosition);
 const ScrollState = Schema.Struct({ _scrollKey: Schema.String });
 /** @internal */
 const decodeScrollState = Schema.decodeUnknownOption(ScrollState);
-
-const interpolateNavigationPath = (
-  targetPath: string,
-  params: Record<string, string | number>,
-): Effect.Effect<string, NavigationError> =>
-  interpolateParams(targetPath, params).pipe(
-    Effect.mapError((cause) => new NavigationError({ operation: "interpolateParams", cause })),
-  );
-
-const interpolateActivePath = (
-  targetPath: string,
-  params: Record<string, string | number>,
-): Effect.Effect<string> => interpolateParams(targetPath, params).pipe(Effect.orDie);
 
 // F-001: Viewport prefetch constants from framework research
 /** IntersectionObserver threshold - 10% visible triggers prefetch */
@@ -675,17 +663,89 @@ export const browserLayer: Layer.Layer<
 
     const prefetchStateRef = yield* Ref.make<OutletPrefetchState>({ _tag: "Idle" });
 
-    // Update signals from a path
-    const updateFromPath = (fullPath: string) =>
-      Effect.gen(function* () {
-        const { path: newPath, query: newQuery } = yield* parsePath(fullPath);
-        yield* Signal.set(currentSignal, {
-          path: newPath,
-          params: {},
-          query: newQuery,
-        });
-        yield* Signal.set(querySignal, newQuery);
+    const navigationAdapter = {
+      read: Effect.gen(function* () {
+        const fullPath = yield* location.fullPath.pipe(
+          Effect.mapError((cause) =>
+            new NavigationCoreError({ operation: "location.fullPath", cause }),
+          ),
+        );
+        const { path: snapshotPath, query } = yield* parsePath(fullPath).pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "parsePath", cause })),
+        );
+        const hash = yield* location.hash.pipe(
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "location.hash", cause })),
+        );
+        return {
+          path: snapshotPath,
+          query,
+          isPopstate: false,
+          hash,
+          scrollKey: currentNavKey,
+        };
+      }),
+      push: (url: string, state: unknown) =>
+        history.pushState(state, url).pipe(
+          Effect.tap(() => {
+            const scrollState = decodeScrollState(state);
+            if (Option.isSome(scrollState)) {
+              currentNavKey = scrollState.value._scrollKey;
+            }
+            return Effect.void;
+          }),
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "pushState", cause })),
+        ),
+      replace: (url: string, state: unknown) =>
+        history.replaceState(state, url).pipe(
+          Effect.tap(() => {
+            const scrollState = decodeScrollState(state);
+            if (Option.isSome(scrollState)) {
+              currentNavKey = scrollState.value._scrollKey;
+            }
+            return Effect.void;
+          }),
+          Effect.mapError((cause) => new NavigationCoreError({ operation: "replaceState", cause })),
+        ),
+      back: history.back.pipe(
+        Effect.mapError((cause) => new NavigationCoreError({ operation: "history.back", cause })),
+      ),
+      forward: history.forward.pipe(
+        Effect.mapError((cause) => new NavigationCoreError({ operation: "history.forward", cause })),
+      ),
+    };
+    const navigationCore = yield* makeNavigationCore(
+      { notifyUnchangedQuery: false },
+      navigationAdapter,
+    ).pipe(Effect.mapError((cause) => new NavigationError({ operation: cause.operation, cause })));
+
+    const applyNavigationSnapshot = Effect.fn("RouterService.applyNavigationSnapshot")(function* () {
+      const current = yield* Signal.get(currentSignal);
+      const snapshot = yield* navigationCore.current;
+      yield* Signal.set(currentSignal, {
+        path: snapshot.path,
+        params: {},
+        query: snapshot.query,
       });
+      yield* ContractTrace.emit({
+        event: "router.current.set",
+        level: "semantic",
+        payload: { fromPath: current.path, toPath: snapshot.path },
+      });
+      const queryChanged = !sameQuery(current.query, snapshot.query);
+      if (queryChanged) {
+        yield* Signal.set(querySignal, snapshot.query);
+      }
+      yield* ContractTrace.emit({
+        event: "router.query.set",
+        level: "semantic",
+        payload: {
+          fromQuery: current.query.toString(),
+          toQuery: snapshot.query.toString(),
+          changed: queryChanged,
+          notified: queryChanged,
+        },
+      });
+    });
 
     // Save scroll using captured services (best-effort, errors ignored)
     const doSaveScroll = () =>
@@ -778,9 +838,9 @@ export const browserLayer: Layer.Layer<
           scrollKey: currentNavKey,
         });
 
-        // Read current location and update signals
-        const currentPath = yield* location.fullPath;
-        yield* updateFromPath(currentPath);
+        // Read current location and update shared navigation state/signals.
+        yield* navigationCore.refresh.pipe(Effect.ignore);
+        yield* applyNavigationSnapshot().pipe(Effect.ignore);
       }).pipe(Effect.ignore),
     );
 
@@ -798,10 +858,11 @@ export const browserLayer: Layer.Layer<
         const traceId = Debug.nextTraceId();
         yield* Debug.setTraceId(traceId);
 
-        // Interpolate params into path pattern if provided
-        const resolvedPath = options?.params
-          ? yield* interpolateNavigationPath(targetPath, options.params)
-          : targetPath;
+        const target = navigationTarget(targetPath, options);
+        const fullPath = yield* resolveNavigationTarget(target).pipe(
+          Effect.mapError((cause) => new NavigationError({ operation: cause.operation, cause })),
+        );
+        const { path: resolvedPath } = yield* parsePath(fullPath);
 
         const current = yield* Signal.get(currentSignal);
         yield* ContractTrace.emit({
@@ -826,73 +887,28 @@ export const browserLayer: Layer.Layer<
         // Save scroll position before navigating away (best-effort)
         yield* doSaveScroll();
 
-        const fullPath = yield* buildPath(resolvedPath, options?.query);
+        yield* navigationCore.navigate(target).pipe(
+          Effect.mapError((cause) => new NavigationError({ operation: cause.operation, cause })),
+        );
 
-        // Generate new key for this navigation entry
-        const newKey = yield* generateKey;
-        const historyState = { _scrollKey: newKey };
-
-        if (options?.replace) {
-          yield* history
-            .replaceState(historyState, fullPath)
-            .pipe(
-              Effect.mapError((cause) => new NavigationError({ operation: "replaceState", cause })),
-            );
-          yield* ContractTrace.emit({
-            event: "history.replace",
-            level: "semantic",
-            payload: { path: fullPath },
-          });
-        } else {
-          yield* history
-            .pushState(historyState, fullPath)
-            .pipe(
-              Effect.mapError((cause) => new NavigationError({ operation: "pushState", cause })),
-            );
-          yield* ContractTrace.emit({
-            event: "history.push",
-            level: "semantic",
-            payload: { path: fullPath },
-          });
-        }
-
-        currentNavKey = newKey;
-
-        // Set navigation context for outlet scroll handling
         const hash = yield* location.hash.pipe(Effect.orElseSucceed(() => ""));
         yield* Ref.set(navContextRef, {
           isPopstate: false,
           hash,
           scrollKey: currentNavKey,
         });
-
-        const { path: newPath, query: newQuery } = yield* parsePath(fullPath);
-        yield* Signal.set(currentSignal, {
-          path: newPath,
-          params: {},
-          query: newQuery,
-        });
         yield* ContractTrace.emit({
-          event: "router.current.set",
+          event: options?.replace ? "history.replace" : "history.push",
           level: "semantic",
-          payload: { fromPath: current.path, toPath: newPath },
+          payload: { path: fullPath },
         });
-        yield* Signal.set(querySignal, newQuery);
-        yield* ContractTrace.emit({
-          event: "router.query.set",
-          level: "semantic",
-          payload: {
-            fromQuery: current.query.toString(),
-            toQuery: newQuery.toString(),
-            changed: current.query.toString() !== newQuery.toString(),
-            notified: current.query.toString() !== newQuery.toString(),
-          },
-        });
+        yield* applyNavigationSnapshot();
+        const snapshot = yield* navigationCore.current;
 
         yield* ContractTrace.emit({
           event: "router.navigate.commit",
           level: "semantic",
-          payload: { path: fullPath, query: newQuery.toString() },
+          payload: { path: fullPath, query: snapshot.query.toString() },
         });
         yield* Debug.log({
           event: "router.navigate.complete",
@@ -903,7 +919,7 @@ export const browserLayer: Layer.Layer<
       back: () =>
         Effect.gen(function* () {
           const before = yield* Signal.get(currentSignal);
-          yield* history.back.pipe(Effect.ignore);
+          yield* navigationCore.back.pipe(Effect.ignore);
           const after = yield* Signal.get(currentSignal);
           yield* ContractTrace.emit({
             event: "history.back",
@@ -915,7 +931,7 @@ export const browserLayer: Layer.Layer<
       forward: () =>
         Effect.gen(function* () {
           const before = yield* Signal.get(currentSignal);
-          yield* history.forward.pipe(Effect.ignore);
+          yield* navigationCore.forward.pipe(Effect.ignore);
           const after = yield* Signal.get(currentSignal);
           yield* ContractTrace.emit({
             event: "history.forward",
@@ -929,12 +945,12 @@ export const browserLayer: Layer.Layer<
 
       isActive: (targetPath: string, options?: IsActiveOptions) =>
         Effect.gen(function* () {
-          const resolvedPath = options?.params
-            ? yield* interpolateActivePath(targetPath, options.params)
-            : targetPath;
+          const target = navigationTarget(targetPath, options);
+          const resolvedPath = yield* resolveNavigationTarget(target).pipe(Effect.orDie);
+          const pathOnly = resolvedPath.split("?")[0] ?? resolvedPath;
           const matcher = options?.exact
-            ? (route: Route) => route.path === resolvedPath
-            : (route: Route) => route.path.startsWith(resolvedPath);
+            ? (route: Route) => route.path === pathOnly
+            : (route: Route) => route.path.startsWith(pathOnly);
           return yield* Signal.derive(currentSignal, matcher);
         }),
 


### PR DESCRIPTION
## Summary

- Moves `Router.browserLayer` push/replace/back/forward/current/query state updates onto `NavigationCore`.
- Isolates browser-specific history/location/popstate/scroll-key behavior inside a NavigationAdapter-compatible adapter.
- Extends the shared navigation law suite to run against both in-memory and browser-like adapters.

## DX impact

Before:

```ts
// Browser and test routers each hand-rolled navigation state transitions.
yield* router.navigate("/users/:id", { params: { id: 42 }, query: { tab: "main" } })
```

After:

```ts
// Public facade is unchanged, but both adapters share NavigationCore transition laws.
yield* router.navigate("/users/:id", { params: { id: 42 }, query: { tab: "main" } })
```

## Acceptance criteria

From #229 / #215:

- [x] Browser Router layer delegates push, replace, back, forward, current route, query, and active-check behavior to NavigationCore.
- [x] Browser-specific History/Location/popstate logic is isolated in a NavigationAdapter-compatible implementation.
- [x] Shared navigation law tests run against both in-memory and browser-like adapters where practical.
- [x] Existing browser-oriented Router service tests continue to pass.
- [x] No new route rendering, Outlet, or prefetch ownership leaks into the browser adapter.

## Weird spots or spots that need attention

- Browser popstate still owns the browser-only scroll-state update before refreshing NavigationCore, because scroll restoration keys are runtime adapter state.
- Facade-level trace/debug/metric events remain in `Router.browserLayer` to avoid changing verifier-facing event names in this adapter delegation slice.
- The browser-like law suite uses a deterministic fake adapter rather than real DOM history so the shared laws stay fast and focused.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. **#248** 👈 current
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->