### PR TITLE
feat(core): add navigation outlet coordination

### DIFF
--- a/packages/core/src/router/__tests__/navigation-outlet-coordination.test.ts
+++ b/packages/core/src/router/__tests__/navigation-outlet-coordination.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { Effect, Option, Ref } from "effect";
+import { unsafeEraseR } from "../../internal/unsafe.js";
+import { makeNavigationOutletCoordination } from "../navigation-outlet-coordination.js";
+
+describe("NavigationOutletCoordination", () => {
+  const makeCoordination = makeNavigationOutletCoordination({ replayLatestPrefetchState: true });
+
+  it("keeps prefetch idle before activation", async () => {
+    const result = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const coordination = yield* makeCoordination;
+          yield* coordination.prefetch("/idle");
+          return yield* coordination.prefetchState;
+        }),
+      ),
+    );
+
+    expect(result._tag).toBe("Idle");
+  });
+
+  it("uses the active prefetch resolver after activation", async () => {
+    const calls = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const coordination = yield* makeCoordination;
+          const callsRef = yield* Ref.make<Array<string>>([]);
+          yield* coordination.activatePrefetch((path) => Ref.update(callsRef, (paths) => [...paths, path]));
+          yield* coordination.prefetch("/active");
+          return yield* Ref.get(callsRef);
+        }),
+      ),
+    );
+
+    expect(calls).toEqual(["/active"]);
+  });
+
+  it("uses the latest resolver after replacement", async () => {
+    const calls = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const coordination = yield* makeCoordination;
+          const callsRef = yield* Ref.make<Array<string>>([]);
+          yield* coordination.activatePrefetch((path) =>
+            Ref.update(callsRef, (paths) => [...paths, `first:${path}`]),
+          );
+          yield* coordination.activatePrefetch((path) =>
+            Ref.update(callsRef, (paths) => [...paths, `second:${path}`]),
+          );
+          yield* coordination.prefetch("/replaced");
+          return yield* Ref.get(callsRef);
+        }),
+      ),
+    );
+
+    expect(calls).toEqual(["second:/replaced"]);
+  });
+
+  it("consumes scroll intent once", async () => {
+    const [first, second] = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const coordination = yield* makeCoordination;
+          yield* coordination.publishScrollIntent({
+            isPopstate: true,
+            hash: "#docs",
+            scrollKey: "nav-1",
+          });
+          const first = yield* coordination.takeScrollIntent;
+          const second = yield* coordination.takeScrollIntent;
+          return [first, second] as const;
+        }),
+      ),
+    );
+
+    expect(Option.getOrUndefined(first)).toEqual({
+      isPopstate: true,
+      hash: "#docs",
+      scrollKey: "nav-1",
+    });
+    expect(Option.isNone(second)).toBe(true);
+  });
+});

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -171,6 +171,18 @@ export type {
   NavigationCoreShape,
 } from "./navigation-core.js";
 
+// Navigation Outlet Coordination
+export {
+  NavigationOutletCoordination,
+  NavigationOutletCoordinationConfigInput,
+  makeNavigationOutletCoordination,
+} from "./navigation-outlet-coordination.js";
+export type {
+  NavigationPrefetchState,
+  ScrollIntent,
+  NavigationOutletCoordinationShape,
+} from "./navigation-outlet-coordination.js";
+
 // Route Builder
 export {
   make as routeMake,

--- a/packages/core/src/router/navigation-outlet-coordination.ts
+++ b/packages/core/src/router/navigation-outlet-coordination.ts
@@ -1,0 +1,84 @@
+/**
+ * Coordination seam between navigation, prefetch, and Outlet scroll activation.
+ *
+ * @remarks
+ * NavigationOutletCoordination owns the mutable router-to-outlet handshake for
+ * mounted prefetch resolvers and one-shot scroll intent. It deliberately does
+ * not match routes, render UI, load components, or perform browser scrolling.
+ *
+ * @since 1.0.0
+ * @module trygg/router/navigation-outlet-coordination
+ */
+import { Deferred, Effect, Layer, Option, Ref, Schema } from "effect";
+import * as Context from "effect/Context";
+
+export type NavigationPrefetchState =
+  | { readonly _tag: "Idle" }
+  | { readonly _tag: "Active"; readonly prefetch: (path: string) => Effect.Effect<void> };
+
+export interface ScrollIntent {
+  readonly isPopstate: boolean;
+  readonly hash: string;
+  readonly scrollKey: string;
+}
+
+export const NavigationOutletCoordinationConfigInput = Schema.Struct({
+  replayLatestPrefetchState: Schema.Boolean,
+});
+
+type NavigationOutletCoordinationConfig = typeof NavigationOutletCoordinationConfigInput.Type;
+
+export interface NavigationOutletCoordinationShape {
+  readonly prefetchState: Effect.Effect<NavigationPrefetchState>;
+  readonly activatePrefetch: (
+    prefetch: (path: string) => Effect.Effect<void>,
+  ) => Effect.Effect<void>;
+  readonly prefetch: (path: string) => Effect.Effect<void>;
+  readonly publishScrollIntent: (intent: ScrollIntent) => Effect.Effect<void>;
+  readonly takeScrollIntent: Effect.Effect<Option.Option<ScrollIntent>>;
+  readonly outletReady: Effect.Effect<Deferred.Deferred<void>>;
+}
+
+export const makeNavigationOutletCoordination = (
+  input: NavigationOutletCoordinationConfig,
+): Effect.Effect<NavigationOutletCoordinationShape> =>
+  Effect.gen(function* () {
+    const config = NavigationOutletCoordinationConfigInput.make(input);
+    const prefetchStateRef = yield* Ref.make<NavigationPrefetchState>({ _tag: "Idle" });
+    const scrollIntentRef = yield* Ref.make<Option.Option<ScrollIntent>>(Option.none());
+    const outletReady = yield* Deferred.make<void>();
+
+    return {
+      prefetchState: Ref.get(prefetchStateRef),
+      activatePrefetch: Effect.fn("NavigationOutletCoordination.activatePrefetch")(function* (
+        prefetch,
+      ) {
+        yield* Ref.set(prefetchStateRef, { _tag: "Active", prefetch });
+        yield* Deferred.succeed(outletReady, void 0).pipe(Effect.ignore);
+        void config;
+      }),
+      prefetch: Effect.fn("NavigationOutletCoordination.prefetch")(function* (path) {
+        const state = yield* Ref.get(prefetchStateRef);
+        if (state._tag === "Active") {
+          yield* state.prefetch(path);
+        }
+      }),
+      publishScrollIntent: Effect.fn("NavigationOutletCoordination.publishScrollIntent")(
+        function* (intent) {
+          yield* Ref.set(scrollIntentRef, Option.some(intent));
+        },
+      ),
+      takeScrollIntent: Ref.getAndSet(scrollIntentRef, Option.none()),
+      outletReady: Effect.succeed(outletReady),
+    };
+  });
+
+export class NavigationOutletCoordination extends Context.Service<
+  NavigationOutletCoordination,
+  NavigationOutletCoordinationShape
+>()("trygg/NavigationOutletCoordination") {
+  static readonly layer = (
+    input: NavigationOutletCoordinationConfig,
+  ): Layer.Layer<NavigationOutletCoordination> =>
+    Layer.effect(NavigationOutletCoordination, makeNavigationOutletCoordination(input));
+}

--- a/packages/core/src/router/service.ts
+++ b/packages/core/src/router/service.ts
@@ -25,7 +25,6 @@ import type {
   RouterService,
   NavigateOptions,
   NavigationContext,
-  OutletPrefetchState,
   IsActiveOptions,
   RouteErrorInfo,
   RoutePath,
@@ -51,6 +50,7 @@ import {
   resolveNavigationTarget,
   sameQuery,
 } from "./navigation-core.js";
+import { makeNavigationOutletCoordination } from "./navigation-outlet-coordination.js";
 
 /** @internal */
 const ScrollPosition = Schema.Struct({ x: Schema.Number, y: Schema.Number });
@@ -661,7 +661,9 @@ export const browserLayer: Layer.Layer<
       scrollKey: currentNavKey,
     });
 
-    const prefetchStateRef = yield* Ref.make<OutletPrefetchState>({ _tag: "Idle" });
+    const outletCoordination = yield* makeNavigationOutletCoordination({
+      replayLatestPrefetchState: true,
+    });
 
     const navigationAdapter = {
       read: Effect.gen(function* () {
@@ -837,6 +839,11 @@ export const browserLayer: Layer.Layer<
           hash,
           scrollKey: currentNavKey,
         });
+        yield* outletCoordination.publishScrollIntent({
+          isPopstate: true,
+          hash,
+          scrollKey: currentNavKey,
+        });
 
         // Read current location and update shared navigation state/signals.
         yield* navigationCore.refresh.pipe(Effect.ignore);
@@ -893,6 +900,11 @@ export const browserLayer: Layer.Layer<
 
         const hash = yield* location.hash.pipe(Effect.orElseSucceed(() => ""));
         yield* Ref.set(navContextRef, {
+          isPopstate: false,
+          hash,
+          scrollKey: currentNavKey,
+        });
+        yield* outletCoordination.publishScrollIntent({
           isPopstate: false,
           hash,
           scrollKey: currentNavKey,
@@ -959,18 +971,17 @@ export const browserLayer: Layer.Layer<
           event: "router.prefetch.start",
           path: targetPath,
         });
-        const prefetchState = yield* Ref.get(prefetchStateRef);
-        if (prefetchState._tag === "Active") {
-          yield* prefetchState.prefetch(targetPath);
-        }
+        yield* outletCoordination.prefetch(targetPath);
       }),
 
       outletCoordination: {
-        prefetchState: Ref.get(prefetchStateRef),
-        activatePrefetch: (prefetch) => Ref.set(prefetchStateRef, { _tag: "Active", prefetch }),
+        prefetchState: outletCoordination.prefetchState,
+        activatePrefetch: outletCoordination.activatePrefetch,
         applyScroll: (opts) =>
           Effect.gen(function* () {
-            const navCtx = yield* Ref.get(navContextRef);
+            const intent = yield* outletCoordination.takeScrollIntent;
+            const navCtx = Option.isSome(intent) ? intent.value : yield* Ref.get(navContextRef);
+            yield* Ref.set(navContextRef, navCtx);
             yield* doApplyScroll({
               strategy: opts.strategy,
               hash: navCtx.hash,
@@ -1032,7 +1043,9 @@ export const testLayer = (
 
       const querySignal = yield* Signal.make<URLSearchParams>(initialQuery);
 
-      const prefetchStateRef = yield* Ref.make<OutletPrefetchState>({ _tag: "Idle" });
+      const outletCoordination = yield* makeNavigationOutletCoordination({
+        replayLatestPrefetchState: true,
+      });
 
       const navigationAdapter = yield* makeInMemoryNavigationAdapter(initialPath).pipe(Effect.orDie);
       const navigationCore = yield* makeNavigationCore(
@@ -1108,6 +1121,12 @@ export const testLayer = (
           yield* navigationCore.navigate(target).pipe(
             Effect.mapError((cause) => new NavigationError({ operation: cause.operation, cause })),
           );
+          const snapshotAfterNavigate = yield* navigationCore.current;
+          yield* outletCoordination.publishScrollIntent({
+            isPopstate: false,
+            hash: snapshotAfterNavigate.hash,
+            scrollKey: snapshotAfterNavigate.scrollKey,
+          });
           yield* ContractTrace.emit({
             event: options?.replace ? "history.replace" : "history.push",
             level: "semantic",
@@ -1171,16 +1190,13 @@ export const testLayer = (
             event: "router.prefetch.start",
             path: targetPath,
           });
-          const prefetchState = yield* Ref.get(prefetchStateRef);
-          if (prefetchState._tag === "Active") {
-            yield* prefetchState.prefetch(targetPath);
-          }
+          yield* outletCoordination.prefetch(targetPath);
         }),
 
         outletCoordination: {
-          prefetchState: Ref.get(prefetchStateRef),
-          activatePrefetch: (prefetch) => Ref.set(prefetchStateRef, { _tag: "Active", prefetch }),
-          applyScroll: () => Effect.void,
+          prefetchState: outletCoordination.prefetchState,
+          activatePrefetch: outletCoordination.activatePrefetch,
+          applyScroll: () => outletCoordination.takeScrollIntent.pipe(Effect.asVoid),
         },
         _saveScroll: Effect.void,
       };

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -25,6 +25,7 @@ import { Component } from "../primitives/component.js";
 import type { Signal } from "../primitives/signal.js";
 import type { Element } from "../primitives/element.js";
 import type { ScrollStrategyType } from "./scroll-strategy.js";
+import type { NavigationPrefetchState } from "./navigation-outlet-coordination.js";
 import {
   compileRoutePathPattern,
   interpolateCompiledRoutePathPattern,
@@ -598,9 +599,7 @@ export interface RouterService {
  * @public
  * @since 1.0.0
  */
-export type OutletPrefetchState =
-  | { readonly _tag: "Idle" }
-  | { readonly _tag: "Active"; readonly prefetch: (path: string) => Effect.Effect<void> };
+export type OutletPrefetchState = NavigationPrefetchState;
 
 /**
  * Public coordination seam from Router service to Outlet.


### PR DESCRIPTION
## Summary

- Adds `NavigationOutletCoordination` as the dedicated NavigationCore-to-Outlet seam for prefetch activation and one-shot scroll intent.
- Routes Router/Link prefetch calls and Outlet resolver activation through the coordination service instead of ad hoc prefetch refs.
- Publishes scroll intent from browser/test navigation and consumes it once when Outlet applies scroll behavior.

## DX impact

Before:

```ts
// Router-owned ad hoc state carried the mounted Outlet prefetch resolver.
yield* router.outletCoordination.activatePrefetch(prefetch)
yield* router.prefetch("/docs")
```

After:

```ts
// Public Router DX is unchanged; internally, prefetch + scroll intent share one seam.
yield* router.outletCoordination.activatePrefetch(prefetch)
yield* router.prefetch("/docs")
```

## Acceptance criteria

From #230 / #216:

- [x] NavigationOutletCoordination exists with service shape compatible with #216.
- [x] Router/Link prefetch and Outlet resolver activation use NavigationOutletCoordination instead of ad hoc Router service state.
- [x] Scroll intent is represented and consumed once through NavigationOutletCoordination.
- [x] Tests cover idle prefetch, active prefetch, resolver replacement, and one-shot scroll intent consumption.
- [x] If RouterService.outletCoordination is removed, all internal callers and tests are migrated in the same slice. (Kept as a thin canary facade; state now delegates to NavigationOutletCoordination.)

## Weird spots or spots that need attention

- `RouterService.outletCoordination` remains as a thin facade to avoid broad Outlet/test churn in this slice; the ad hoc mutable state behind it was removed.
- Browser scroll execution stays in `Router.browserLayer`; the new coordination service only carries scroll intent and deliberately does not perform DOM scroll.
- `replayLatestPrefetchState` is accepted by the config to match the ICD shape, but no queuing/replay policy is introduced in this slice.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. **#249** 👈 current
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->