### PR TITLE
feat(core): add route activation commit seam

### DIFF
--- a/packages/core/src/router/__tests__/route-activation.test.ts
+++ b/packages/core/src/router/__tests__/route-activation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { Effect, Option } from "effect";
+import { unsafeEraseR } from "../../internal/unsafe.js";
+import type { RouteMatch, RouteMatcherShape } from "../matching.js";
+import { makeRouteActivation } from "../route-activation.js";
+
+const request = (activationId: string, path: string) => ({
+  activationId,
+  path,
+  query: new URLSearchParams(),
+  scrollIntent: Option.none(),
+});
+
+const makeMatcher = (matchPath: string): RouteMatcherShape => ({
+  routes: Effect.succeed([]),
+  match: (path) =>
+    Effect.succeed(
+      path === matchPath
+        ? Option.some({ route: { path: matchPath, ancestors: [], definition: {} }, params: {} } as unknown as RouteMatch)
+        : Option.none(),
+    ),
+});
+
+describe("RouteActivation", () => {
+  it("commits the latest activation", async () => {
+    const outcome = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation({ emitTraceEvents: true });
+          yield* activation.activate(request("nav-1", "/docs"));
+          return yield* activation.commit({ activationId: "nav-1", path: "/docs" });
+        }),
+      ),
+    );
+
+    expect(outcome).toEqual({ _tag: "Committed", activationId: "nav-1", path: "/docs" });
+  });
+
+  it("drops stale activations when a newer activation wins", async () => {
+    const outcome = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation({ emitTraceEvents: true });
+          yield* activation.activate(request("nav-1", "/slow"));
+          yield* activation.activate(request("nav-2", "/fast"));
+          return yield* activation.commit({ activationId: "nav-1", path: "/slow" });
+        }),
+      ),
+    );
+
+    expect(outcome).toEqual({
+      _tag: "DroppedStale",
+      activationId: "nav-1",
+      supersededBy: "nav-2",
+    });
+  });
+
+  it("returns NotFound when the canonical matcher has no match", async () => {
+    const outcome = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation(
+            { emitTraceEvents: true },
+            makeMatcher("/known"),
+          );
+          return yield* activation.activate(request("nav-1", "/missing"));
+        }),
+      ),
+    );
+
+    expect(outcome).toEqual({ _tag: "NotFound", activationId: "nav-1", path: "/missing" });
+  });
+
+  it("integrates with the canonical matcher for matched routes", async () => {
+    const outcome = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation(
+            { emitTraceEvents: true },
+            makeMatcher("/known"),
+          );
+          return yield* activation.activate(request("nav-1", "/known"));
+        }),
+      ),
+    );
+
+    expect(outcome).toEqual({ _tag: "Committed", activationId: "nav-1", path: "/known" });
+  });
+});

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -183,6 +183,20 @@ export type {
   NavigationOutletCoordinationShape,
 } from "./navigation-outlet-coordination.js";
 
+// Route Activation
+export {
+  RouteActivation,
+  RouteActivationError,
+  RouteActivationConfigInput,
+  makeRouteActivation,
+} from "./route-activation.js";
+export type {
+  RouteActivationRequest,
+  RouteActivationOutcome,
+  RouteActivationShape,
+  RouteActivationMatch,
+} from "./route-activation.js";
+
 // Route Builder
 export {
   make as routeMake,

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -64,6 +64,7 @@ import {
   type AsyncLoaderShape,
 } from "./outlet-services.js";
 import { RenderLoadError } from "./render-strategy.js";
+import { makeRouteActivation } from "./route-activation.js";
 import { ScrollStrategy } from "./scroll-strategy.js";
 import {
   type ComponentInput,
@@ -553,6 +554,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       return text("No routes configured");
     }
     const matcher = matcherOpt.value;
+    const routeActivation = yield* makeRouteActivation({ emitTraceEvents: true }, matcher);
     const boundaries: BoundaryResolverShape = BoundaryResolver.make(manifest);
 
     const router = yield* getRouter;
@@ -646,9 +648,27 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
     // Set in processRoute, consumed by loader.view subscription after Ready state.
     // loader.track() forks a render fiber and returns immediately — scroll must
     // wait until the Ready state propagates and the DOM has been swapped.
-    let pendingScroll: { readonly strategyLayer: Layer.Layer<ScrollStrategy> | undefined } | null =
-      null;
+    let pendingScroll: {
+      readonly activationId: string;
+      readonly strategyLayer: Layer.Layer<ScrollStrategy> | undefined;
+    } | null = null;
     let routeEpoch = 0;
+
+    const nextActivationId = () => `route-${++routeEpoch}`;
+
+    const mayCommitActivation = (activationId: string, path: string) =>
+      Effect.gen(function* () {
+        const outcome = yield* routeActivation.commit({ activationId, path });
+        if (outcome._tag === "DroppedStale") {
+          yield* ContractTrace.emit({
+            event: "outlet.process.dropStale",
+            level: "semantic",
+            payload: { activationId, supersededBy: outcome.supersededBy, path },
+          });
+          return false;
+        }
+        return true;
+      });
 
     /**
      * Process a route: match, middleware, boundaries, render, update view.
@@ -809,8 +829,10 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               const state = yield* SubscriptionRef.get(loader.state._ref);
               const val = yield* SubscriptionRef.get(loader.view._ref);
               if (pendingScroll !== null && state._tag === "Ready") {
-                const { strategyLayer } = pendingScroll;
+                const { activationId, strategyLayer } = pendingScroll;
                 pendingScroll = null;
+                const canCommit = yield* mayCommitActivation(activationId, "async-loader");
+                if (!canCommit) return;
                 yield* setViewAndAwaitSwap(val);
                 yield* applyScroll(strategyLayer);
               } else {
@@ -830,6 +852,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       match: RouteMatch,
       queryString: string,
       epoch: number,
+      activationId: string,
       routePath: string,
     ) =>
       Effect.gen(function* () {
@@ -842,12 +865,14 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           // Defer scroll across loading/refreshing states. `track` forks the
           // render fiber, so fast loads can already be Ready by the time it
           // returns; handle that window explicitly after track.
-          pendingScroll = { strategyLayer };
+          pendingScroll = { activationId, strategyLayer };
           yield* loader.track(matchKey, renderEffect, { epoch });
           const currentState = yield* SubscriptionRef.get(loader.state._ref);
           const currentView = yield* SubscriptionRef.get(loader.view._ref);
           if (pendingScroll !== null && currentState._tag === "Ready") {
             pendingScroll = null;
+            const canCommit = yield* mayCommitActivation(activationId, routePath);
+            if (!canCommit) return;
             yield* setViewAndAwaitSwap(currentView);
             yield* ContractTrace.emit({
               event: "outlet.process.commit",
@@ -875,7 +900,10 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
             });
           }
         } else {
-          yield* setViewAndAwaitSwap(yield* renderEffect);
+          const rendered = yield* renderEffect;
+          const canCommit = yield* mayCommitActivation(activationId, routePath);
+          if (!canCommit) return;
+          yield* setViewAndAwaitSwap(rendered);
           yield* ContractTrace.emit({
             event: "outlet.process.commit",
             level: "semantic",
@@ -893,14 +921,22 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       // Clear stale scroll intent from prior navigation
       pendingScroll = null;
 
-      const epoch = ++routeEpoch;
+      const activationId = nextActivationId();
+      const epoch = routeEpoch;
       const route = yield* SubscriptionRef.get(router.current._ref);
       yield* ContractTrace.emit({
         event: "outlet.process.start",
         level: "semantic",
-        payload: { path: route.path, epoch },
+        payload: { path: route.path, epoch, activationId },
       });
-      const matchOption = yield* matcher.match(route.path);
+      const activationOutcome = yield* routeActivation.activate({
+        activationId,
+        path: route.path,
+        query: route.query,
+        scrollIntent: Option.none(),
+      });
+      const matchOption =
+        activationOutcome._tag === "NotFound" ? Option.none() : yield* matcher.match(route.path);
 
       // 404
       if (Option.isNone(matchOption)) {
@@ -914,6 +950,8 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           onSome: (comp) =>
             Effect.flatMap(resolveComponent(comp), (resolved) => renderComponent(resolved, {}, {})),
         });
+        const canCommit = yield* mayCommitActivation(activationId, route.path);
+        if (!canCommit) return;
         yield* setViewAndAwaitSwap(notFoundEl);
         yield* applyScroll(undefined);
         return;
@@ -939,6 +977,8 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           onSome: (comp) =>
             Effect.flatMap(resolveComponent(comp), (resolved) => renderComponent(resolved, {}, {})),
         });
+        const canCommit = yield* mayCommitActivation(activationId, route.path);
+        if (!canCommit) return;
         yield* setViewAndAwaitSwap(el);
         yield* applyScroll(resolveScrollStrategy(match.route));
         return;
@@ -951,6 +991,8 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               renderError(resolved, Cause.fail(middlewareResult.cause), route.path),
             ),
         });
+        const canCommit = yield* mayCommitActivation(activationId, route.path);
+        if (!canCommit) return;
         yield* setViewAndAwaitSwap(el);
         yield* applyScroll(resolveScrollStrategy(match.route));
         return;
@@ -974,6 +1016,8 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               renderError(resolved, Cause.fail(decodedParamsResult.failure), route.path),
             ),
         });
+        const canCommit = yield* mayCommitActivation(activationId, route.path);
+        if (!canCommit) return;
         yield* setViewAndAwaitSwap(el);
         yield* applyScroll(resolveScrollStrategy(match.route));
         return;
@@ -997,6 +1041,8 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               renderError(resolved, Cause.fail(decodedQueryResult.failure), route.path),
             ),
         });
+        const canCommit = yield* mayCommitActivation(activationId, route.path);
+        if (!canCommit) return;
         yield* setViewAndAwaitSwap(el);
         yield* applyScroll(resolveScrollStrategy(match.route));
         return;
@@ -1011,7 +1057,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
         deferLazyLeaf: !hasLoadingBoundary,
       });
       const withError = wrapWithErrorBoundary(routeElement, match, route.path);
-      yield* commitView(withError, match, queryString, epoch, route.path);
+      yield* commitView(withError, match, queryString, epoch, activationId, route.path);
     }).pipe(
       Effect.catchCause((cause) =>
         Effect.gen(function* () {

--- a/packages/core/src/router/route-activation.ts
+++ b/packages/core/src/router/route-activation.ts
@@ -1,0 +1,110 @@
+/**
+ * Current-route activation coordination for Outlet.
+ *
+ * @remarks
+ * RouteActivation owns latest-activation identity and stale commit suppression.
+ * Outlet remains responsible for rendering elements and DOM replacement, while
+ * this seam decides whether a route activation is still current before visible
+ * UI may commit.
+ *
+ * @since 1.0.0
+ * @module trygg/router/route-activation
+ */
+import { Data, Deferred, Effect, Layer, Option, Schema, SynchronizedRef } from "effect";
+import * as Context from "effect/Context";
+import type { ScrollIntent } from "./navigation-outlet-coordination.js";
+import type { RouteMatch, RouteMatcherShape } from "./matching.js";
+
+export interface RouteActivationRequest {
+  readonly activationId: string;
+  readonly path: string;
+  readonly query: URLSearchParams;
+  readonly scrollIntent: Option.Option<ScrollIntent>;
+}
+
+export type RouteActivationOutcome =
+  | { readonly _tag: "Committed"; readonly activationId: string; readonly path: string }
+  | { readonly _tag: "DroppedStale"; readonly activationId: string; readonly supersededBy: string }
+  | { readonly _tag: "NotFound"; readonly activationId: string; readonly path: string };
+
+export class RouteActivationError extends Data.TaggedError("RouteActivationError")<{
+  readonly activationId: string;
+  readonly path: string;
+  readonly cause: unknown;
+}> {}
+
+export const RouteActivationConfigInput = Schema.Struct({
+  emitTraceEvents: Schema.Boolean,
+});
+
+type RouteActivationConfig = typeof RouteActivationConfigInput.Type;
+
+export interface RouteActivationShape {
+  readonly activate: (
+    request: RouteActivationRequest,
+  ) => Effect.Effect<RouteActivationOutcome, RouteActivationError>;
+  readonly commit: (
+    request: Pick<RouteActivationRequest, "activationId" | "path">,
+  ) => Effect.Effect<RouteActivationOutcome>;
+  readonly currentActivationId: Effect.Effect<Option.Option<string>>;
+  readonly waitForDomSwap: (activationId: string) => Effect.Effect<Deferred.Deferred<void>>;
+}
+
+export const makeRouteActivation = (
+  input: RouteActivationConfig,
+  matcher?: RouteMatcherShape,
+): Effect.Effect<RouteActivationShape> =>
+  Effect.gen(function* () {
+    const config = RouteActivationConfigInput.make(input);
+    const current = yield* SynchronizedRef.make<Option.Option<string>>(Option.none());
+
+    const currentOrStale = (activationId: string, path: string): Effect.Effect<RouteActivationOutcome> =>
+      Effect.gen(function* () {
+        const latest = yield* SynchronizedRef.get(current);
+        if (Option.isSome(latest) && latest.value !== activationId) {
+          return { _tag: "DroppedStale", activationId, supersededBy: latest.value } as const;
+        }
+        return { _tag: "Committed", activationId, path } as const;
+      });
+
+    return {
+      activate: Effect.fn("RouteActivation.activate")(function* (request) {
+        yield* SynchronizedRef.set(current, Option.some(request.activationId));
+        if (matcher !== undefined) {
+          const match = yield* matcher.match(request.path).pipe(
+            Effect.mapError(
+              (cause) =>
+                new RouteActivationError({
+                  activationId: request.activationId,
+                  path: request.path,
+                  cause,
+                }),
+            ),
+          );
+          if (Option.isNone(match)) {
+            return { _tag: "NotFound", activationId: request.activationId, path: request.path };
+          }
+        }
+        void config;
+        return { _tag: "Committed", activationId: request.activationId, path: request.path };
+      }),
+      commit: Effect.fn("RouteActivation.commit")(function* (request) {
+        return yield* currentOrStale(request.activationId, request.path);
+      }),
+      currentActivationId: SynchronizedRef.get(current),
+      waitForDomSwap: Effect.fn("RouteActivation.waitForDomSwap")(function* (_activationId) {
+        return yield* Deferred.make<void>();
+      }),
+    };
+  });
+
+export class RouteActivation extends Context.Service<RouteActivation, RouteActivationShape>()(
+  "trygg/RouteActivation",
+) {
+  static readonly layer = (
+    input: RouteActivationConfig,
+    matcher?: RouteMatcherShape,
+  ): Layer.Layer<RouteActivation> => Layer.effect(RouteActivation, makeRouteActivation(input, matcher));
+}
+
+export type RouteActivationMatch = RouteMatch;


### PR DESCRIPTION
## Summary

- Adds `RouteActivation` as the Outlet-adjacent seam for activation ids, matcher-backed not-found outcomes, and stale commit suppression.
- Wires `Outlet` route processing through `RouteActivation` before matching/committing visible UI.
- Adds route activation contract tests for latest-navigation wins, stale drop, not-found, and matcher integration.

## DX impact

Before:

```ts
// Outlet owned route epochs and commit timing inline while rendering.
<Outlet />
```

After:

```ts
// Public DX is unchanged; latest-route commit decisions now go through RouteActivation.
<Outlet />
```

## Acceptance criteria

From #231 / #217:

- [x] RouteActivation exists with service shape compatible with #217.
- [x] Outlet delegates current route processing and latest-route commit checks to RouteActivation.
- [x] Tests cover latest navigation wins, stale activation drop/suppression, not-found activation outcome, and route match integration.
- [x] Stale Route render guards are removed from scattered Outlet/Renderer code where RouteActivation now owns them. (The remaining AsyncLoader epoch is still passed to the loader, but visible Outlet commit checks are centralized through RouteActivation.)
- [x] Existing navigation-latest-route-wins behavior contract still passes.

## Weird spots or spots that need attention

- `RouteActivation` intentionally coordinates commit permission only in this slice; loading fallback ownership and richer boundary outcomes are left for #232/#233/#234.
- Outlet still performs rendering and DOM swap mechanics; RouteActivation only decides whether an activation is still latest before visible UI commits.
- AsyncLoader keeps its existing epoch input for loader-local ordering, while RouteActivation owns the final visible commit suppression.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. **#250** 👈 current
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->