### PR TITLE
feat(core): coordinate route activation loading and scroll

### DIFF
--- a/packages/core/src/router/__tests__/route-activation.test.ts
+++ b/packages/core/src/router/__tests__/route-activation.test.ts
@@ -71,6 +71,88 @@ describe("RouteActivation", () => {
     expect(outcome).toEqual({ _tag: "NotFound", activationId: "nav-1", path: "/missing" });
   });
 
+  it("controls loading fallback display for the latest activation", async () => {
+    const events = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation({ emitTraceEvents: true });
+          const events: Array<string> = [];
+          yield* activation.activate(request("nav-1", "/slow"));
+          yield* activation.showLoadingFallback(
+            { activationId: "nav-1", path: "/slow" },
+            Effect.sync(() => events.push("loading")),
+          );
+          return events;
+        }),
+      ),
+    );
+
+    expect(events).toEqual(["loading"]);
+  });
+
+  it("suppresses stale loading fallback display", async () => {
+    const events = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation({ emitTraceEvents: true });
+          const events: Array<string> = [];
+          yield* activation.activate(request("nav-1", "/slow"));
+          yield* activation.activate(request("nav-2", "/fast"));
+          yield* activation.showLoadingFallback(
+            { activationId: "nav-1", path: "/slow" },
+            Effect.sync(() => events.push("stale-loading")),
+          );
+          return events;
+        }),
+      ),
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  it("runs scroll work only after the activation DOM swap", async () => {
+    const events = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation({ emitTraceEvents: true });
+          const events: Array<string> = [];
+          yield* activation.activate(request("nav-1", "/docs"));
+          yield* activation.commitAfterDomSwap(
+            { activationId: "nav-1", path: "/docs" },
+            Effect.sync(() => events.push("swap")),
+            Effect.sync(() => events.push("scroll")),
+          );
+          return events;
+        }),
+      ),
+    );
+
+    expect(events).toEqual(["swap", "scroll"]);
+  });
+
+  it("suppresses scroll if the activation becomes stale during DOM swap", async () => {
+    const events = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const activation = yield* makeRouteActivation({ emitTraceEvents: true });
+          const events: Array<string> = [];
+          yield* activation.activate(request("nav-1", "/slow"));
+          yield* activation.commitAfterDomSwap(
+            { activationId: "nav-1", path: "/slow" },
+            Effect.gen(function* () {
+              events.push("swap");
+              yield* activation.activate(request("nav-2", "/fast")).pipe(Effect.orDie);
+            }),
+            Effect.sync(() => events.push("stale-scroll")),
+          );
+          return events;
+        }),
+      ),
+    );
+
+    expect(events).toEqual(["swap"]);
+  });
+
   it("integrates with the canonical matcher for matched routes", async () => {
     const outcome = await Effect.runPromise(
       unsafeEraseR(

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -650,25 +650,13 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
     // wait until the Ready state propagates and the DOM has been swapped.
     let pendingScroll: {
       readonly activationId: string;
+      readonly routePath: string;
       readonly strategyLayer: Layer.Layer<ScrollStrategy> | undefined;
     } | null = null;
     let routeEpoch = 0;
 
     const nextActivationId = () => `route-${++routeEpoch}`;
 
-    const mayCommitActivation = (activationId: string, path: string) =>
-      Effect.gen(function* () {
-        const outcome = yield* routeActivation.commit({ activationId, path });
-        if (outcome._tag === "DroppedStale") {
-          yield* ContractTrace.emit({
-            event: "outlet.process.dropStale",
-            level: "semantic",
-            payload: { activationId, supersededBy: outcome.supersededBy, path },
-          });
-          return false;
-        }
-        return true;
-      });
 
     /**
      * Process a route: match, middleware, boundaries, render, update view.
@@ -829,12 +817,18 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               const state = yield* SubscriptionRef.get(loader.state._ref);
               const val = yield* SubscriptionRef.get(loader.view._ref);
               if (pendingScroll !== null && state._tag === "Ready") {
-                const { activationId, strategyLayer } = pendingScroll;
+                const { activationId, routePath, strategyLayer } = pendingScroll;
                 pendingScroll = null;
-                const canCommit = yield* mayCommitActivation(activationId, "async-loader");
-                if (!canCommit) return;
-                yield* setViewAndAwaitSwap(val);
-                yield* applyScroll(strategyLayer);
+                yield* routeActivation.commitAfterDomSwap(
+                  { activationId, path: routePath },
+                  setViewAndAwaitSwap(val),
+                  applyScroll(strategyLayer),
+                );
+              } else if (pendingScroll !== null) {
+                yield* routeActivation.showLoadingFallback(
+                  { activationId: pendingScroll.activationId, path: pendingScroll.routePath },
+                  Signal.set(viewSignal, val),
+                );
               } else {
                 yield* Signal.set(viewSignal, val);
               }
@@ -865,15 +859,17 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           // Defer scroll across loading/refreshing states. `track` forks the
           // render fiber, so fast loads can already be Ready by the time it
           // returns; handle that window explicitly after track.
-          pendingScroll = { activationId, strategyLayer };
+          pendingScroll = { activationId, routePath, strategyLayer };
           yield* loader.track(matchKey, renderEffect, { epoch });
           const currentState = yield* SubscriptionRef.get(loader.state._ref);
           const currentView = yield* SubscriptionRef.get(loader.view._ref);
           if (pendingScroll !== null && currentState._tag === "Ready") {
             pendingScroll = null;
-            const canCommit = yield* mayCommitActivation(activationId, routePath);
-            if (!canCommit) return;
-            yield* setViewAndAwaitSwap(currentView);
+            yield* routeActivation.commitAfterDomSwap(
+              { activationId, path: routePath },
+              setViewAndAwaitSwap(currentView),
+              applyScroll(strategyLayer),
+            );
             yield* ContractTrace.emit({
               event: "outlet.process.commit",
               level: "semantic",
@@ -884,9 +880,11 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
                 epoch,
               },
             });
-            yield* applyScroll(strategyLayer);
           } else {
-            yield* Signal.set(viewSignal, currentView);
+            yield* routeActivation.showLoadingFallback(
+              { activationId, path: routePath },
+              Signal.set(viewSignal, currentView),
+            );
             yield* ContractTrace.emit({
               event: "outlet.process.commit",
               level: "semantic",
@@ -901,15 +899,16 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           }
         } else {
           const rendered = yield* renderEffect;
-          const canCommit = yield* mayCommitActivation(activationId, routePath);
-          if (!canCommit) return;
-          yield* setViewAndAwaitSwap(rendered);
+          yield* routeActivation.commitAfterDomSwap(
+            { activationId, path: routePath },
+            setViewAndAwaitSwap(rendered),
+            applyScroll(resolveScrollStrategy(match.route)),
+          );
           yield* ContractTrace.emit({
             event: "outlet.process.commit",
             level: "semantic",
             payload: { path: routePath, routePattern: match.route.path, query: queryString, epoch },
           });
-          yield* applyScroll(resolveScrollStrategy(match.route));
         }
       });
 
@@ -950,10 +949,11 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           onSome: (comp) =>
             Effect.flatMap(resolveComponent(comp), (resolved) => renderComponent(resolved, {}, {})),
         });
-        const canCommit = yield* mayCommitActivation(activationId, route.path);
-        if (!canCommit) return;
-        yield* setViewAndAwaitSwap(notFoundEl);
-        yield* applyScroll(undefined);
+        yield* routeActivation.commitAfterDomSwap(
+          { activationId, path: route.path },
+          setViewAndAwaitSwap(notFoundEl),
+          applyScroll(undefined),
+        );
         return;
       }
 
@@ -977,10 +977,11 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           onSome: (comp) =>
             Effect.flatMap(resolveComponent(comp), (resolved) => renderComponent(resolved, {}, {})),
         });
-        const canCommit = yield* mayCommitActivation(activationId, route.path);
-        if (!canCommit) return;
-        yield* setViewAndAwaitSwap(el);
-        yield* applyScroll(resolveScrollStrategy(match.route));
+        yield* routeActivation.commitAfterDomSwap(
+          { activationId, path: route.path },
+          setViewAndAwaitSwap(el),
+          applyScroll(resolveScrollStrategy(match.route)),
+        );
         return;
       }
       if (middlewareResult._tag === "Error") {
@@ -991,10 +992,11 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               renderError(resolved, Cause.fail(middlewareResult.cause), route.path),
             ),
         });
-        const canCommit = yield* mayCommitActivation(activationId, route.path);
-        if (!canCommit) return;
-        yield* setViewAndAwaitSwap(el);
-        yield* applyScroll(resolveScrollStrategy(match.route));
+        yield* routeActivation.commitAfterDomSwap(
+          { activationId, path: route.path },
+          setViewAndAwaitSwap(el),
+          applyScroll(resolveScrollStrategy(match.route)),
+        );
         return;
       }
 
@@ -1016,10 +1018,11 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               renderError(resolved, Cause.fail(decodedParamsResult.failure), route.path),
             ),
         });
-        const canCommit = yield* mayCommitActivation(activationId, route.path);
-        if (!canCommit) return;
-        yield* setViewAndAwaitSwap(el);
-        yield* applyScroll(resolveScrollStrategy(match.route));
+        yield* routeActivation.commitAfterDomSwap(
+          { activationId, path: route.path },
+          setViewAndAwaitSwap(el),
+          applyScroll(resolveScrollStrategy(match.route)),
+        );
         return;
       }
 
@@ -1041,10 +1044,11 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               renderError(resolved, Cause.fail(decodedQueryResult.failure), route.path),
             ),
         });
-        const canCommit = yield* mayCommitActivation(activationId, route.path);
-        if (!canCommit) return;
-        yield* setViewAndAwaitSwap(el);
-        yield* applyScroll(resolveScrollStrategy(match.route));
+        yield* routeActivation.commitAfterDomSwap(
+          { activationId, path: route.path },
+          setViewAndAwaitSwap(el),
+          applyScroll(resolveScrollStrategy(match.route)),
+        );
         return;
       }
 

--- a/packages/core/src/router/route-activation.ts
+++ b/packages/core/src/router/route-activation.ts
@@ -48,6 +48,15 @@ export interface RouteActivationShape {
   ) => Effect.Effect<RouteActivationOutcome>;
   readonly currentActivationId: Effect.Effect<Option.Option<string>>;
   readonly waitForDomSwap: (activationId: string) => Effect.Effect<Deferred.Deferred<void>>;
+  readonly showLoadingFallback: (
+    request: Pick<RouteActivationRequest, "activationId" | "path">,
+    show: Effect.Effect<void>,
+  ) => Effect.Effect<RouteActivationOutcome>;
+  readonly commitAfterDomSwap: (
+    request: Pick<RouteActivationRequest, "activationId" | "path">,
+    swap: Effect.Effect<void>,
+    afterSwap: Effect.Effect<void>,
+  ) => Effect.Effect<RouteActivationOutcome>;
 }
 
 export const makeRouteActivation = (
@@ -94,6 +103,28 @@ export const makeRouteActivation = (
       currentActivationId: SynchronizedRef.get(current),
       waitForDomSwap: Effect.fn("RouteActivation.waitForDomSwap")(function* (_activationId) {
         return yield* Deferred.make<void>();
+      }),
+      showLoadingFallback: Effect.fn("RouteActivation.showLoadingFallback")(function* (
+        request,
+        show,
+      ) {
+        const outcome = yield* currentOrStale(request.activationId, request.path);
+        if (outcome._tag === "DroppedStale") return outcome;
+        yield* show;
+        return outcome;
+      }),
+      commitAfterDomSwap: Effect.fn("RouteActivation.commitAfterDomSwap")(function* (
+        request,
+        swap,
+        afterSwap,
+      ) {
+        const beforeSwap = yield* currentOrStale(request.activationId, request.path);
+        if (beforeSwap._tag === "DroppedStale") return beforeSwap;
+        yield* swap;
+        const afterDomSwap = yield* currentOrStale(request.activationId, request.path);
+        if (afterDomSwap._tag === "DroppedStale") return afterDomSwap;
+        yield* afterSwap;
+        return afterDomSwap;
       }),
     };
   });


### PR DESCRIPTION
## Summary

- Extends `RouteActivation` to coordinate loading fallback display and scroll-after-DOM-swap timing.
- Moves Outlet fallback display and scroll timing calls through RouteActivation helpers.
- Adds contract tests for latest fallback display, stale fallback suppression, scroll-after-swap ordering, and stale scroll suppression.

## DX impact

Before:

```ts
// Outlet independently decided when to show loading and when to scroll after swapping.
<Outlet />
```

After:

```ts
// Public DX is unchanged; activation state owns fallback and scroll timing decisions.
<Outlet />
```

## Acceptance criteria

From #232 / #217:

- [x] RouteActivation controls when a pending route shows its loading fallback.
- [x] Scroll application runs after the relevant activation DOM swap, never before it.
- [x] Tests cover loading fallback display, stale fallback suppression, and scroll-after-swap timing.
- [x] Outlet no longer owns independent fallback/scroll timing logic that can drift from RouteActivation.
- [x] Existing route rendering and scroll behavior remains externally unchanged.

## Weird spots or spots that need attention

- RouteActivation still receives Outlet-owned swap/scroll Effects rather than performing DOM replacement itself; this preserves the RenderTransaction boundary for later slices.
- AsyncLoader keeps its loader-local state machine, but fallback visibility and ready-scroll sequencing now route through RouteActivation.
- No timeout was introduced; stale suppression is identity-based only.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. **#251** 👈 current
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->