### PR TITLE
feat(core): add route activation lazy outcomes

### DIFF
--- a/packages/core/src/router/__tests__/route-activation.test.ts
+++ b/packages/core/src/router/__tests__/route-activation.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { Effect, Option } from "effect";
+import { Effect, Option, Ref } from "effect";
 import { unsafeEraseR } from "../../internal/unsafe.js";
 import type { RouteMatch, RouteMatcherShape } from "../matching.js";
-import { makeRouteActivation } from "../route-activation.js";
+import { makeRouteActivation, makeRouteActivationBoundary } from "../route-activation.js";
+import type { ComponentInput, RouteComponent } from "../types.js";
 
 const request = (activationId: string, path: string) => ({
   activationId,
@@ -11,14 +12,22 @@ const request = (activationId: string, path: string) => ({
   scrollIntent: Option.none(),
 });
 
-const makeMatcher = (matchPath: string): RouteMatcherShape => ({
+const makeMatch = (
+  path: string,
+  definition: Record<string, unknown> = {},
+): RouteMatch =>
+  ({
+    route: {
+      path,
+      ancestors: [],
+      definition: { prefetch: [], ...definition },
+    },
+    params: {},
+  }) as unknown as RouteMatch;
+
+const makeMatcher = (matchPath: string, match: RouteMatch = makeMatch(matchPath)): RouteMatcherShape => ({
   routes: Effect.succeed([]),
-  match: (path) =>
-    Effect.succeed(
-      path === matchPath
-        ? Option.some({ route: { path: matchPath, ancestors: [], definition: {} }, params: {} } as unknown as RouteMatch)
-        : Option.none(),
-    ),
+  match: (path) => Effect.succeed(path === matchPath ? Option.some(match) : Option.none()),
 });
 
 describe("RouteActivation", () => {
@@ -151,6 +160,146 @@ describe("RouteActivation", () => {
     );
 
     expect(events).toEqual(["swap"]);
+  });
+
+  it("resolves lazy loader routes to the nearest loading intent", async () => {
+    const loader = (() => Promise.resolve({ default: Effect.succeed({ _tag: "Text", value: "Lazy" }) })) as ComponentInput;
+    const loading = Effect.succeed({ _tag: "Text", value: "Loading" }) as unknown as ComponentInput;
+    const match = makeMatch("/lazy", { component: loader, loading });
+    const intent = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const boundary = yield* makeRouteActivationBoundary(
+            { interruptStaleLoads: true },
+            {
+              matcher: makeMatcher("/lazy", match),
+              collectPrefetchTargets: () => [loader],
+              isComponentLoader: (component) => component === loader,
+              loadComponent: () => Effect.succeed(Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent),
+              runRoutePrefetch: () => Effect.void,
+              resolveLoading: () => Option.some(loading),
+              isStale: () => Effect.succeed(false),
+            },
+          );
+          return yield* boundary.resolve(request("nav-1", "/lazy"), match);
+        }),
+      ),
+    );
+
+    expect(intent._tag).toBe("Loading");
+    if (intent._tag === "Loading") {
+      expect(intent.component).toBe(loading);
+    }
+  });
+
+  it("loads lazy components through RouteActivationBoundary", async () => {
+    const loaded = Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent;
+    const component = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/lazy");
+          const boundary = yield* makeRouteActivationBoundary(
+            { interruptStaleLoads: true },
+            {
+              matcher: makeMatcher("/lazy", match),
+              collectPrefetchTargets: () => [],
+              isComponentLoader: () => true,
+              loadComponent: () => Effect.succeed(loaded),
+              runRoutePrefetch: () => Effect.void,
+              resolveLoading: () => Option.none(),
+              isStale: () => Effect.succeed(false),
+            },
+          );
+          return yield* boundary.loadComponent(request("nav-1", "/lazy"), (() => Promise.resolve({ default: loaded })) as ComponentInput);
+        }),
+      ),
+    );
+
+    expect(component).toBe(loaded);
+  });
+
+  it("normalizes lazy load failures", async () => {
+    const exit = await Effect.runPromiseExit(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/lazy");
+          const boundary = yield* makeRouteActivationBoundary(
+            { interruptStaleLoads: true },
+            {
+              matcher: makeMatcher("/lazy", match),
+              collectPrefetchTargets: () => [],
+              isComponentLoader: () => true,
+              loadComponent: () => Effect.fail("boom"),
+              runRoutePrefetch: () => Effect.void,
+              resolveLoading: () => Option.none(),
+              isStale: () => Effect.succeed(false),
+            },
+          );
+          return yield* boundary.loadComponent(request("nav-1", "/lazy"), (() => Promise.resolve({ default: null })) as ComponentInput);
+        }),
+      ),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(String(exit.cause)).toContain("LazyRouteLoadError");
+    }
+  });
+
+  it("prefetches lazy modules best-effort", async () => {
+    const calls = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const callsRef = yield* Ref.make<Array<string>>([]);
+          const loader = (() => Promise.resolve({ default: null })) as ComponentInput;
+          const match = makeMatch("/lazy");
+          const boundary = yield* makeRouteActivationBoundary(
+            { interruptStaleLoads: true },
+            {
+              matcher: makeMatcher("/lazy", match),
+              collectPrefetchTargets: () => [loader],
+              isComponentLoader: (component) => component === loader,
+              loadComponent: () => Ref.update(callsRef, (calls) => [...calls, "module"]).pipe(Effect.as(Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent)),
+              runRoutePrefetch: () => Ref.update(callsRef, (calls) => [...calls, "route"]),
+              resolveLoading: () => Option.none(),
+              isStale: () => Effect.succeed(false),
+            },
+          );
+          yield* boundary.prefetch("/lazy");
+          return yield* Ref.get(callsRef);
+        }),
+      ),
+    );
+
+    expect(calls).toEqual(["module", "route"]);
+  });
+
+  it("suppresses stale lazy load results", async () => {
+    const exit = await Effect.runPromiseExit(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/lazy");
+          const boundary = yield* makeRouteActivationBoundary(
+            { interruptStaleLoads: true },
+            {
+              matcher: makeMatcher("/lazy", match),
+              collectPrefetchTargets: () => [],
+              isComponentLoader: () => true,
+              loadComponent: () => Effect.succeed(Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent),
+              runRoutePrefetch: () => Effect.void,
+              resolveLoading: () => Option.none(),
+              isStale: () => Effect.succeed(true),
+            },
+          );
+          return yield* boundary.loadComponent(request("nav-1", "/lazy"), (() => Promise.resolve({ default: null })) as ComponentInput);
+        }),
+      ),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(String(exit.cause)).toContain("LazyRouteLoadError");
+    }
   });
 
   it("integrates with the canonical matcher for matched routes", async () => {

--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -186,14 +186,22 @@ export type {
 // Route Activation
 export {
   RouteActivation,
+  RouteActivationBoundary,
   RouteActivationError,
+  LazyRouteLoadError,
+  BoundaryResolutionError,
   RouteActivationConfigInput,
+  RouteActivationBoundaryConfigInput,
   makeRouteActivation,
+  makeRouteActivationBoundary,
 } from "./route-activation.js";
 export type {
   RouteActivationRequest,
   RouteActivationOutcome,
   RouteActivationShape,
+  RouteActivationBoundaryShape,
+  RouteActivationBoundaryDependencies,
+  RouteActivationRenderIntent,
   RouteActivationMatch,
 } from "./route-activation.js";
 

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -64,7 +64,8 @@ import {
   type AsyncLoaderShape,
 } from "./outlet-services.js";
 import { RenderLoadError } from "./render-strategy.js";
-import { makeRouteActivation } from "./route-activation.js";
+import { makeRouteActivation, makeRouteActivationBoundary } from "./route-activation.js";
+import type { RouteActivationRequest } from "./route-activation.js";
 import { ScrollStrategy } from "./scroll-strategy.js";
 import {
   type ComponentInput,
@@ -556,15 +557,47 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
     const matcher = matcherOpt.value;
     const routeActivation = yield* makeRouteActivation({ emitTraceEvents: true }, matcher);
     const boundaries: BoundaryResolverShape = BoundaryResolver.make(manifest);
+    const routeActivationBoundary = yield* makeRouteActivationBoundary(
+      { interruptStaleLoads: true },
+      {
+        matcher,
+        collectPrefetchTargets,
+        isComponentLoader: (component) => isComponentLoader(component),
+        loadComponent: (component) => resolveComponent(component),
+        runRoutePrefetch: (path, match, query) =>
+          Effect.gen(function* () {
+            const prefetchFns = match.route.definition.prefetch;
+            if (prefetchFns.length === 0) return;
+            const decodedParamsResult = yield* decodeRouteParams(match.route, match.params).pipe(
+              Effect.result,
+            );
+            if (Result.isFailure(decodedParamsResult)) return;
+            const decodedQueryResult = yield* decodeRouteQuery(match.route, query).pipe(
+              Effect.result,
+            );
+            if (Result.isFailure(decodedQueryResult)) return;
+            yield* runPrefetch(prefetchFns, {
+              params: decodedParamsResult.success,
+              query: decodedQueryResult.success,
+            });
+            void path;
+          }),
+        resolveLoading: (match) => boundaries.resolveLoading(match.route),
+        isStale: (activationId) =>
+          Effect.gen(function* () {
+            const current = yield* routeActivation.currentActivationId;
+            return Option.isSome(current) && current.value !== activationId;
+          }),
+      },
+    );
 
     const router = yield* getRouter;
 
     // Register prefetch resolver so router.prefetch() can warm lazy modules
     const currentMatcher = yield* Ref.get(cachedMatcherRef);
     if (Option.isSome(currentMatcher)) {
-      yield* router.outletCoordination.activatePrefetch(
-        buildPrefetchResolver(currentMatcher.value),
-      );
+      void currentMatcher;
+      yield* router.outletCoordination.activatePrefetch(routeActivationBoundary.prefetch);
     }
 
     const componentScope = yield* Signal.CurrentComponentScope;
@@ -673,7 +706,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       decodedParams: Record<string, unknown>,
       decodedQuery: Record<string, unknown>,
       routePath: string,
-      options: { readonly deferLazyLeaf: boolean },
+      options: { readonly deferLazyLeaf: boolean; readonly request: RouteActivationRequest },
     ): Effect.Effect<Element, unknown, never> => {
       const renderLazyLeaf = (
         loader: ComponentLoader,
@@ -690,7 +723,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
                   level: "semantic",
                   payload: { path: routeIdentity.path },
                 });
-                const component = yield* resolveComponent(loader);
+                const component = yield* routeActivationBoundary.loadComponent(options.request, loader);
                 const leafElement = yield* renderComponent(
                   component,
                   decodedParams,
@@ -1059,6 +1092,12 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       const hasLoadingBoundary = Option.isSome(boundaries.resolveLoading(match.route));
       const routeElement = buildRouteElement(match, decodedParams, decodedQuery, route.path, {
         deferLazyLeaf: !hasLoadingBoundary,
+        request: {
+          activationId,
+          path: route.path,
+          query: route.query,
+          scrollIntent: Option.none(),
+        },
       });
       const withError = wrapWithErrorBoundary(routeElement, match, route.path);
       yield* commitView(withError, match, queryString, epoch, activationId, route.path);

--- a/packages/core/src/router/route-activation.ts
+++ b/packages/core/src/router/route-activation.ts
@@ -10,10 +10,12 @@
  * @since 1.0.0
  * @module trygg/router/route-activation
  */
-import { Data, Deferred, Effect, Layer, Option, Schema, SynchronizedRef } from "effect";
+import { Data, Deferred, Effect, Layer, Option, Schema, Scope, SynchronizedRef } from "effect";
 import * as Context from "effect/Context";
 import type { ScrollIntent } from "./navigation-outlet-coordination.js";
 import type { RouteMatch, RouteMatcherShape } from "./matching.js";
+import type { ComponentInput, RouteComponent } from "./types.js";
+import { parsePath } from "./utils.js";
 
 export interface RouteActivationRequest {
   readonly activationId: string;
@@ -136,6 +138,138 @@ export class RouteActivation extends Context.Service<RouteActivation, RouteActiv
     input: RouteActivationConfig,
     matcher?: RouteMatcherShape,
   ): Layer.Layer<RouteActivation> => Layer.effect(RouteActivation, makeRouteActivation(input, matcher));
+}
+
+export type RouteActivationRenderIntent =
+  | { readonly _tag: "Leaf"; readonly component: ComponentInput }
+  | { readonly _tag: "Loading"; readonly component: ComponentInput }
+  | { readonly _tag: "ErrorBoundary"; readonly component: ComponentInput; readonly cause: unknown }
+  | { readonly _tag: "NotFoundBoundary"; readonly component: ComponentInput }
+  | { readonly _tag: "ForbiddenBoundary"; readonly component: ComponentInput }
+  | { readonly _tag: "Redirect"; readonly location: string }
+  | { readonly _tag: "NoBoundary"; readonly cause: unknown };
+
+export class LazyRouteLoadError extends Data.TaggedError("LazyRouteLoadError")<{
+  readonly activationId: string;
+  readonly path: string;
+  readonly cause: unknown;
+}> {}
+
+export class BoundaryResolutionError extends Data.TaggedError("BoundaryResolutionError")<{
+  readonly activationId: string;
+  readonly path: string;
+  readonly reason: string;
+}> {}
+
+export const RouteActivationBoundaryConfigInput = Schema.Struct({
+  interruptStaleLoads: Schema.Boolean,
+});
+
+type RouteActivationBoundaryConfig = typeof RouteActivationBoundaryConfigInput.Type;
+
+export interface RouteActivationBoundaryDependencies {
+  readonly matcher: RouteMatcherShape;
+  readonly collectPrefetchTargets: (match: RouteMatch) => ReadonlyArray<ComponentInput>;
+  readonly isComponentLoader: (component: ComponentInput) => boolean;
+  readonly loadComponent: (component: ComponentInput) => Effect.Effect<RouteComponent, unknown>;
+  readonly runRoutePrefetch: (path: string, match: RouteMatch, query: URLSearchParams) => Effect.Effect<void>;
+  readonly resolveLoading: (match: RouteMatch) => Option.Option<ComponentInput>;
+  readonly isStale: (activationId: string) => Effect.Effect<boolean>;
+}
+
+export interface RouteActivationBoundaryShape {
+  readonly resolve: (
+    request: RouteActivationRequest,
+    match: RouteMatch,
+  ) => Effect.Effect<
+    RouteActivationRenderIntent,
+    LazyRouteLoadError | BoundaryResolutionError,
+    Scope.Scope
+  >;
+  readonly prefetch: (path: string) => Effect.Effect<void>;
+  readonly loadComponent: (
+    request: RouteActivationRequest,
+    component: ComponentInput,
+  ) => Effect.Effect<RouteComponent, LazyRouteLoadError>;
+}
+
+export const makeRouteActivationBoundary = (
+  input: RouteActivationBoundaryConfig,
+  dependencies: RouteActivationBoundaryDependencies,
+): Effect.Effect<RouteActivationBoundaryShape> =>
+  Effect.gen(function* () {
+    const config = RouteActivationBoundaryConfigInput.make(input);
+
+    const loadForActivation = Effect.fn("RouteActivationBoundary.loadComponent")(function* (
+      request: RouteActivationRequest,
+      component: ComponentInput,
+    ) {
+      const loaded = yield* dependencies.loadComponent(component).pipe(
+        Effect.mapError(
+          (cause) =>
+            new LazyRouteLoadError({ activationId: request.activationId, path: request.path, cause }),
+        ),
+      );
+      const stale = yield* dependencies.isStale(request.activationId);
+      if (config.interruptStaleLoads && stale) {
+        return yield* new LazyRouteLoadError({
+          activationId: request.activationId,
+          path: request.path,
+          cause: "stale activation",
+        });
+      }
+      return loaded;
+    });
+
+    return {
+      resolve: Effect.fn("RouteActivationBoundary.resolve")(function* (request, match) {
+        if (yield* dependencies.isStale(request.activationId)) {
+          return yield* new BoundaryResolutionError({
+            activationId: request.activationId,
+            path: request.path,
+            reason: "stale activation",
+          });
+        }
+        const loading = dependencies.resolveLoading(match);
+        const component = match.route.definition.component;
+        if (
+          Option.isSome(loading) &&
+          component !== undefined &&
+          dependencies.isComponentLoader(component)
+        ) {
+          return { _tag: "Loading", component: loading.value };
+        }
+        if (component !== undefined) {
+          return { _tag: "Leaf", component };
+        }
+        return { _tag: "NoBoundary", cause: "route has no component" };
+      }),
+      prefetch: Effect.fn("RouteActivationBoundary.prefetch")(function* (path) {
+        const parsed = yield* parsePath(path).pipe(Effect.orDie);
+        const matchOption = yield* dependencies.matcher.match(parsed.path).pipe(Effect.orDie);
+        if (Option.isNone(matchOption)) return;
+        const match = matchOption.value;
+        const targets = dependencies.collectPrefetchTargets(match);
+        yield* Effect.forEach(
+          targets.filter(dependencies.isComponentLoader),
+          (component) => dependencies.loadComponent(component).pipe(Effect.ignore),
+          { concurrency: "unbounded" },
+        );
+        yield* dependencies.runRoutePrefetch(path, match, parsed.query).pipe(Effect.ignore);
+      }),
+      loadComponent: loadForActivation,
+    };
+  });
+
+export class RouteActivationBoundary extends Context.Service<
+  RouteActivationBoundary,
+  RouteActivationBoundaryShape
+>()("trygg/RouteActivationBoundary") {
+  static readonly layer = (
+    input: RouteActivationBoundaryConfig,
+    dependencies: RouteActivationBoundaryDependencies,
+  ): Layer.Layer<RouteActivationBoundary> =>
+    Layer.effect(RouteActivationBoundary, makeRouteActivationBoundary(input, dependencies));
 }
 
 export type RouteActivationMatch = RouteMatch;


### PR DESCRIPTION
## Summary

- Adds `RouteActivationBoundary` for lazy route render intents, lazy component loading, best-effort prefetch, and stale-load suppression.
- Wires Outlet lazy leaf loading and prefetch activation through the new boundary seam.
- Adds contract tests for lazy success, lazy failure normalization, best-effort prefetch, loading intent resolution, and stale lazy load suppression.

## DX impact

Before:

```ts
// Lazy loading and prefetch were Outlet-local details.
Route.make("/docs").component(() => import("./Docs"))
```

After:

```ts
// App code is unchanged; lazy outcomes now flow through RouteActivationBoundary.
Route.make("/docs").component(() => import("./Docs"))
```

## Acceptance criteria

From #233 / #218:

- [x] RouteActivationBoundary exists with resolver/prefetch shape compatible with #218 for lazy loading paths.
- [x] Lazy leaf success, lazy leaf failure, prefetch, and stale-load interruption are handled through RouteActivationBoundary.
- [x] Tests cover lazy success, lazy failure, prefetch best-effort behavior, and stale lazy load suppression/interruption.
- [x] No changes are made to `Component.provide`, provider lifecycle ownership, Effect-owned Layer semantics, or route-level strategy provision.
- [x] Existing #187-related component lifecycle/provision tests remain unaffected.

## Weird spots or spots that need attention

- This intentionally avoids route-level provision/layer semantics; dependencies are injected from Outlet so #187/#190/#193 remain untouched.
- Existing `buildPrefetchResolver` remains exported for compatibility, but mounted Outlet prefetch now delegates through `RouteActivationBoundary.prefetch`.
- Stale lazy loads are normalized as `LazyRouteLoadError`; visible stale commits are still suppressed by the RouteActivation commit seam.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. **#252** 👈 current
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->