### PR TITLE
feat(core): route activation boundary outcomes

### DIFF
--- a/packages/core/src/router/__tests__/route-activation.test.ts
+++ b/packages/core/src/router/__tests__/route-activation.test.ts
@@ -30,6 +30,25 @@ const makeMatcher = (matchPath: string, match: RouteMatch = makeMatch(matchPath)
   match: (path) => Effect.succeed(path === matchPath ? Option.some(match) : Option.none()),
 });
 
+const makeBoundary = (overrides: Partial<Parameters<typeof makeRouteActivationBoundary>[1]> = {}) =>
+  makeRouteActivationBoundary(
+    { interruptStaleLoads: true },
+    {
+      matcher: makeMatcher("/docs"),
+      collectPrefetchTargets: () => [],
+      isComponentLoader: () => false,
+      loadComponent: () => Effect.succeed(Effect.succeed({ _tag: "Text", value: "Loaded" }) as unknown as RouteComponent),
+      runRoutePrefetch: () => Effect.void,
+      resolveLoading: () => Option.none(),
+      resolveError: () => Option.none(),
+      resolveNotFound: () => Option.none(),
+      resolveForbidden: () => Option.none(),
+      runMiddleware: () => Effect.succeed({ _tag: "Continue" }),
+      isStale: () => Effect.succeed(false),
+      ...overrides,
+    },
+  );
+
 describe("RouteActivation", () => {
   it("commits the latest activation", async () => {
     const outcome = await Effect.runPromise(
@@ -178,6 +197,10 @@ describe("RouteActivation", () => {
               loadComponent: () => Effect.succeed(Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent),
               runRoutePrefetch: () => Effect.void,
               resolveLoading: () => Option.some(loading),
+              resolveError: () => Option.none(),
+              resolveNotFound: () => Option.none(),
+              resolveForbidden: () => Option.none(),
+              runMiddleware: () => Effect.succeed({ _tag: "Continue" }),
               isStale: () => Effect.succeed(false),
             },
           );
@@ -207,6 +230,10 @@ describe("RouteActivation", () => {
               loadComponent: () => Effect.succeed(loaded),
               runRoutePrefetch: () => Effect.void,
               resolveLoading: () => Option.none(),
+              resolveError: () => Option.none(),
+              resolveNotFound: () => Option.none(),
+              resolveForbidden: () => Option.none(),
+              runMiddleware: () => Effect.succeed({ _tag: "Continue" }),
               isStale: () => Effect.succeed(false),
             },
           );
@@ -232,6 +259,10 @@ describe("RouteActivation", () => {
               loadComponent: () => Effect.fail("boom"),
               runRoutePrefetch: () => Effect.void,
               resolveLoading: () => Option.none(),
+              resolveError: () => Option.none(),
+              resolveNotFound: () => Option.none(),
+              resolveForbidden: () => Option.none(),
+              runMiddleware: () => Effect.succeed({ _tag: "Continue" }),
               isStale: () => Effect.succeed(false),
             },
           );
@@ -262,6 +293,10 @@ describe("RouteActivation", () => {
               loadComponent: () => Ref.update(callsRef, (calls) => [...calls, "module"]).pipe(Effect.as(Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent)),
               runRoutePrefetch: () => Ref.update(callsRef, (calls) => [...calls, "route"]),
               resolveLoading: () => Option.none(),
+              resolveError: () => Option.none(),
+              resolveNotFound: () => Option.none(),
+              resolveForbidden: () => Option.none(),
+              runMiddleware: () => Effect.succeed({ _tag: "Continue" }),
               isStale: () => Effect.succeed(false),
             },
           );
@@ -288,6 +323,10 @@ describe("RouteActivation", () => {
               loadComponent: () => Effect.succeed(Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent),
               runRoutePrefetch: () => Effect.void,
               resolveLoading: () => Option.none(),
+              resolveError: () => Option.none(),
+              resolveNotFound: () => Option.none(),
+              resolveForbidden: () => Option.none(),
+              runMiddleware: () => Effect.succeed({ _tag: "Continue" }),
               isStale: () => Effect.succeed(true),
             },
           );
@@ -300,6 +339,102 @@ describe("RouteActivation", () => {
     if (exit._tag === "Failure") {
       expect(String(exit.cause)).toContain("LazyRouteLoadError");
     }
+  });
+
+  it("selects the nearest error boundary through RouteActivationBoundary", async () => {
+    const errorBoundary = Effect.succeed({ _tag: "Text", value: "Error" }) as unknown as ComponentInput;
+    const intent = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/docs");
+          const boundary = yield* makeBoundary({ resolveError: () => Option.some(errorBoundary) });
+          return yield* boundary.resolveErrorBoundary(request("nav-1", "/docs"), match, "boom");
+        }),
+      ),
+    );
+
+    expect(intent._tag).toBe("ErrorBoundary");
+    if (intent._tag === "ErrorBoundary") expect(intent.component).toBe(errorBoundary);
+  });
+
+  it("selects the nearest not-found boundary through RouteActivationBoundary", async () => {
+    const notFoundBoundary = Effect.succeed({ _tag: "Text", value: "Missing" }) as unknown as ComponentInput;
+    const intent = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const boundary = yield* makeBoundary({ resolveNotFound: () => Option.some(notFoundBoundary) });
+          return yield* boundary.resolveNotFoundBoundary(request("nav-1", "/missing"));
+        }),
+      ),
+    );
+
+    expect(intent._tag).toBe("NotFoundBoundary");
+    if (intent._tag === "NotFoundBoundary") expect(intent.component).toBe(notFoundBoundary);
+  });
+
+  it("selects the nearest forbidden boundary through RouteActivationBoundary", async () => {
+    const forbiddenBoundary = Effect.succeed({ _tag: "Text", value: "Forbidden" }) as unknown as ComponentInput;
+    const intent = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/admin");
+          const boundary = yield* makeBoundary({ resolveForbidden: () => Option.some(forbiddenBoundary) });
+          return yield* boundary.resolveForbiddenBoundary(request("nav-1", "/admin"), match);
+        }),
+      ),
+    );
+
+    expect(intent._tag).toBe("ForbiddenBoundary");
+    if (intent._tag === "ForbiddenBoundary") expect(intent.component).toBe(forbiddenBoundary);
+  });
+
+  it("represents middleware redirect as a render intent", async () => {
+    const intent = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/private");
+          const boundary = yield* makeBoundary({
+            runMiddleware: () => Effect.succeed({ _tag: "Redirect", path: "/login", replace: true }),
+          });
+          return yield* boundary.resolveMiddleware(request("nav-1", "/private"), match);
+        }),
+      ),
+    );
+
+    expect(intent).toEqual({ _tag: "Redirect", location: "/login", replace: true });
+  });
+
+  it("represents middleware forbidden as a boundary intent", async () => {
+    const forbiddenBoundary = Effect.succeed({ _tag: "Text", value: "Forbidden" }) as unknown as ComponentInput;
+    const intent = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/private");
+          const boundary = yield* makeBoundary({
+            runMiddleware: () => Effect.succeed({ _tag: "Forbidden" }),
+            resolveForbidden: () => Option.some(forbiddenBoundary),
+          });
+          return yield* boundary.resolveMiddleware(request("nav-1", "/private"), match);
+        }),
+      ),
+    );
+
+    expect(intent._tag).toBe("ForbiddenBoundary");
+    if (intent._tag === "ForbiddenBoundary") expect(intent.component).toBe(forbiddenBoundary);
+  });
+
+  it("returns NoBoundary when a boundary is missing", async () => {
+    const intent = await Effect.runPromise(
+      unsafeEraseR(
+        Effect.gen(function* () {
+          const match = makeMatch("/docs");
+          const boundary = yield* makeBoundary();
+          return yield* boundary.resolveErrorBoundary(request("nav-1", "/docs"), match, "boom");
+        }),
+      ),
+    );
+
+    expect(intent._tag).toBe("NoBoundary");
   });
 
   it("integrates with the canonical matcher for matched routes", async () => {

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -583,6 +583,10 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
             void path;
           }),
         resolveLoading: (match) => boundaries.resolveLoading(match.route),
+        resolveError: (match) => boundaries.resolveError(match.route),
+        resolveNotFound: () => boundaries.resolveNotFoundRoot(),
+        resolveForbidden: (match) => boundaries.resolveForbidden(match.route),
+        runMiddleware: (match) => runRouteMiddleware(match.route),
         isStale: (activationId) =>
           Effect.gen(function* () {
             const current = yield* routeActivation.currentActivationId;
@@ -961,12 +965,13 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
         level: "semantic",
         payload: { path: route.path, epoch, activationId },
       });
-      const activationOutcome = yield* routeActivation.activate({
+      const activationRequest: RouteActivationRequest = {
         activationId,
         path: route.path,
         query: route.query,
         scrollIntent: Option.none(),
-      });
+      };
+      const activationOutcome = yield* routeActivation.activate(activationRequest);
       const matchOption =
         activationOutcome._tag === "NotFound" ? Option.none() : yield* matcher.match(route.path);
 
@@ -977,11 +982,15 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           level: "semantic",
           payload: { path: route.path, epoch },
         });
-        const notFoundEl = yield* Option.match(boundaries.resolveNotFoundRoot(), {
-          onNone: () => Effect.succeed(text("404 - Not Found")),
-          onSome: (comp) =>
-            Effect.flatMap(resolveComponent(comp), (resolved) => renderComponent(resolved, {}, {})),
-        });
+        const notFoundIntent = yield* routeActivationBoundary.resolveNotFoundBoundary(
+          activationRequest,
+        );
+        const notFoundEl =
+          notFoundIntent._tag === "NotFoundBoundary"
+            ? yield* Effect.flatMap(resolveComponent(notFoundIntent.component), (resolved) =>
+                renderComponent(resolved, {}, {}),
+              )
+            : text("404 - Not Found");
         yield* routeActivation.commitAfterDomSwap(
           { activationId, path: route.path },
           setViewAndAwaitSwap(notFoundEl),
@@ -998,18 +1007,21 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       });
 
       // Middleware
-      const middlewareResult = yield* runRouteMiddleware(match.route);
+      const middlewareIntent = yield* routeActivationBoundary.resolveMiddleware(
+        activationRequest,
+        match,
+      );
 
-      if (middlewareResult._tag === "Redirect") {
-        yield* router.navigate(middlewareResult.path, { replace: middlewareResult.replace });
+      if (middlewareIntent._tag === "Redirect") {
+        yield* router.navigate(middlewareIntent.location, {
+          ...(middlewareIntent.replace !== undefined ? { replace: middlewareIntent.replace } : {}),
+        });
         return;
       }
-      if (middlewareResult._tag === "Forbidden") {
-        const el = yield* Option.match(boundaries.resolveForbidden(match.route), {
-          onNone: () => Effect.succeed(text("403 - Forbidden")),
-          onSome: (comp) =>
-            Effect.flatMap(resolveComponent(comp), (resolved) => renderComponent(resolved, {}, {})),
-        });
+      if (middlewareIntent._tag === "ForbiddenBoundary") {
+        const el = yield* Effect.flatMap(resolveComponent(middlewareIntent.component), (resolved) =>
+          renderComponent(resolved, {}, {}),
+        );
         yield* routeActivation.commitAfterDomSwap(
           { activationId, path: route.path },
           setViewAndAwaitSwap(el),
@@ -1017,14 +1029,19 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
         );
         return;
       }
-      if (middlewareResult._tag === "Error") {
-        const el = yield* Option.match(boundaries.resolveError(match.route), {
-          onNone: () => Effect.succeed(text("Error")),
-          onSome: (comp) =>
-            Effect.flatMap(resolveComponent(comp), (resolved) =>
-              renderError(resolved, Cause.fail(middlewareResult.cause), route.path),
-            ),
-        });
+      if (middlewareIntent._tag === "ErrorBoundary") {
+        const el = yield* Effect.flatMap(resolveComponent(middlewareIntent.component), (resolved) =>
+          renderError(resolved, Cause.fail(middlewareIntent.cause), route.path),
+        );
+        yield* routeActivation.commitAfterDomSwap(
+          { activationId, path: route.path },
+          setViewAndAwaitSwap(el),
+          applyScroll(resolveScrollStrategy(match.route)),
+        );
+        return;
+      }
+      if (middlewareIntent._tag === "NoBoundary") {
+        const el = text(middlewareIntent.cause === "forbidden" ? "403 - Forbidden" : "Error");
         yield* routeActivation.commitAfterDomSwap(
           { activationId, path: route.path },
           setViewAndAwaitSwap(el),
@@ -1038,19 +1055,22 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
         Effect.result,
       );
       if (Result.isFailure(decodedParamsResult)) {
-        const el = yield* Option.match(boundaries.resolveError(match.route), {
-          onNone: () =>
-            Debug.log({
-              event: "router.outlet.error",
-              phase: "decode_params",
-              path: route.path,
-              error: decodedParamsResult.failure,
-            }).pipe(Effect.as(text("Error"))),
-          onSome: (comp) =>
-            Effect.flatMap(resolveComponent(comp), (resolved) =>
-              renderError(resolved, Cause.fail(decodedParamsResult.failure), route.path),
-            ),
-        });
+        const errorIntent = yield* routeActivationBoundary.resolveErrorBoundary(
+          activationRequest,
+          match,
+          decodedParamsResult.failure,
+        );
+        const el =
+          errorIntent._tag === "ErrorBoundary"
+            ? yield* Effect.flatMap(resolveComponent(errorIntent.component), (resolved) =>
+                renderError(resolved, Cause.fail(decodedParamsResult.failure), route.path),
+              )
+            : yield* Debug.log({
+                event: "router.outlet.error",
+                phase: "decode_params",
+                path: route.path,
+                error: decodedParamsResult.failure,
+              }).pipe(Effect.as(text("Error")));
         yield* routeActivation.commitAfterDomSwap(
           { activationId, path: route.path },
           setViewAndAwaitSwap(el),
@@ -1064,19 +1084,22 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
         Effect.result,
       );
       if (Result.isFailure(decodedQueryResult)) {
-        const el = yield* Option.match(boundaries.resolveError(match.route), {
-          onNone: () =>
-            Debug.log({
-              event: "router.outlet.error",
-              phase: "decode_query",
-              path: route.path,
-              error: decodedQueryResult.failure,
-            }).pipe(Effect.as(text("Error"))),
-          onSome: (comp) =>
-            Effect.flatMap(resolveComponent(comp), (resolved) =>
-              renderError(resolved, Cause.fail(decodedQueryResult.failure), route.path),
-            ),
-        });
+        const errorIntent = yield* routeActivationBoundary.resolveErrorBoundary(
+          activationRequest,
+          match,
+          decodedQueryResult.failure,
+        );
+        const el =
+          errorIntent._tag === "ErrorBoundary"
+            ? yield* Effect.flatMap(resolveComponent(errorIntent.component), (resolved) =>
+                renderError(resolved, Cause.fail(decodedQueryResult.failure), route.path),
+              )
+            : yield* Debug.log({
+                event: "router.outlet.error",
+                phase: "decode_query",
+                path: route.path,
+                error: decodedQueryResult.failure,
+              }).pipe(Effect.as(text("Error")));
         yield* routeActivation.commitAfterDomSwap(
           { activationId, path: route.path },
           setViewAndAwaitSwap(el),

--- a/packages/core/src/router/route-activation.ts
+++ b/packages/core/src/router/route-activation.ts
@@ -14,6 +14,7 @@ import { Data, Deferred, Effect, Layer, Option, Schema, Scope, SynchronizedRef }
 import * as Context from "effect/Context";
 import type { ScrollIntent } from "./navigation-outlet-coordination.js";
 import type { RouteMatch, RouteMatcherShape } from "./matching.js";
+import type { MiddlewareResult } from "./route.js";
 import type { ComponentInput, RouteComponent } from "./types.js";
 import { parsePath } from "./utils.js";
 
@@ -146,7 +147,7 @@ export type RouteActivationRenderIntent =
   | { readonly _tag: "ErrorBoundary"; readonly component: ComponentInput; readonly cause: unknown }
   | { readonly _tag: "NotFoundBoundary"; readonly component: ComponentInput }
   | { readonly _tag: "ForbiddenBoundary"; readonly component: ComponentInput }
-  | { readonly _tag: "Redirect"; readonly location: string }
+  | { readonly _tag: "Redirect"; readonly location: string; readonly replace?: boolean }
   | { readonly _tag: "NoBoundary"; readonly cause: unknown };
 
 export class LazyRouteLoadError extends Data.TaggedError("LazyRouteLoadError")<{
@@ -174,6 +175,10 @@ export interface RouteActivationBoundaryDependencies {
   readonly loadComponent: (component: ComponentInput) => Effect.Effect<RouteComponent, unknown>;
   readonly runRoutePrefetch: (path: string, match: RouteMatch, query: URLSearchParams) => Effect.Effect<void>;
   readonly resolveLoading: (match: RouteMatch) => Option.Option<ComponentInput>;
+  readonly resolveError: (match: RouteMatch, cause: unknown) => Option.Option<ComponentInput>;
+  readonly resolveNotFound: (path: string) => Option.Option<ComponentInput>;
+  readonly resolveForbidden: (match: RouteMatch) => Option.Option<ComponentInput>;
+  readonly runMiddleware: (match: RouteMatch) => Effect.Effect<MiddlewareResult>;
   readonly isStale: (activationId: string) => Effect.Effect<boolean>;
 }
 
@@ -191,6 +196,22 @@ export interface RouteActivationBoundaryShape {
     request: RouteActivationRequest,
     component: ComponentInput,
   ) => Effect.Effect<RouteComponent, LazyRouteLoadError>;
+  readonly resolveErrorBoundary: (
+    request: RouteActivationRequest,
+    match: RouteMatch,
+    cause: unknown,
+  ) => Effect.Effect<RouteActivationRenderIntent, BoundaryResolutionError>;
+  readonly resolveNotFoundBoundary: (
+    request: RouteActivationRequest,
+  ) => Effect.Effect<RouteActivationRenderIntent, BoundaryResolutionError>;
+  readonly resolveForbiddenBoundary: (
+    request: RouteActivationRequest,
+    match: RouteMatch,
+  ) => Effect.Effect<RouteActivationRenderIntent, BoundaryResolutionError>;
+  readonly resolveMiddleware: (
+    request: RouteActivationRequest,
+    match: RouteMatch,
+  ) => Effect.Effect<RouteActivationRenderIntent | { readonly _tag: "Continue" }, BoundaryResolutionError>;
 }
 
 export const makeRouteActivationBoundary = (
@@ -199,6 +220,19 @@ export const makeRouteActivationBoundary = (
 ): Effect.Effect<RouteActivationBoundaryShape> =>
   Effect.gen(function* () {
     const config = RouteActivationBoundaryConfigInput.make(input);
+
+    const staleBoundaryError = (request: RouteActivationRequest) =>
+      new BoundaryResolutionError({
+        activationId: request.activationId,
+        path: request.path,
+        reason: "stale activation",
+      });
+
+    const noBoundary = (request: RouteActivationRequest, reason: string, cause: unknown) => {
+      void request;
+      void reason;
+      return { _tag: "NoBoundary", cause } as const;
+    };
 
     const loadForActivation = Effect.fn("RouteActivationBoundary.loadComponent")(function* (
       request: RouteActivationRequest,
@@ -224,11 +258,7 @@ export const makeRouteActivationBoundary = (
     return {
       resolve: Effect.fn("RouteActivationBoundary.resolve")(function* (request, match) {
         if (yield* dependencies.isStale(request.activationId)) {
-          return yield* new BoundaryResolutionError({
-            activationId: request.activationId,
-            path: request.path,
-            reason: "stale activation",
-          });
+          return yield* staleBoundaryError(request);
         }
         const loading = dependencies.resolveLoading(match);
         const component = match.route.definition.component;
@@ -258,6 +288,60 @@ export const makeRouteActivationBoundary = (
         yield* dependencies.runRoutePrefetch(path, match, parsed.query).pipe(Effect.ignore);
       }),
       loadComponent: loadForActivation,
+      resolveErrorBoundary: Effect.fn("RouteActivationBoundary.resolveErrorBoundary")(function* (
+        request,
+        match,
+        cause,
+      ) {
+        if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
+        const component = dependencies.resolveError(match, cause);
+        return Option.isSome(component)
+          ? { _tag: "ErrorBoundary", component: component.value, cause }
+          : noBoundary(request, "missing error boundary", cause);
+      }),
+      resolveNotFoundBoundary: Effect.fn("RouteActivationBoundary.resolveNotFoundBoundary")(
+        function* (request) {
+          if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
+          const component = dependencies.resolveNotFound(request.path);
+          return Option.isSome(component)
+            ? { _tag: "NotFoundBoundary", component: component.value }
+            : noBoundary(request, "missing not-found boundary", "not found");
+        },
+      ),
+      resolveForbiddenBoundary: Effect.fn("RouteActivationBoundary.resolveForbiddenBoundary")(
+        function* (request, match) {
+          if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
+          const component = dependencies.resolveForbidden(match);
+          return Option.isSome(component)
+            ? { _tag: "ForbiddenBoundary", component: component.value }
+            : noBoundary(request, "missing forbidden boundary", "forbidden");
+        },
+      ),
+      resolveMiddleware: Effect.fn("RouteActivationBoundary.resolveMiddleware")(function* (
+        request,
+        match,
+      ) {
+        if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
+        const result = yield* dependencies.runMiddleware(match);
+        switch (result._tag) {
+          case "Continue":
+            return { _tag: "Continue" } as const;
+          case "Redirect":
+            return { _tag: "Redirect", location: result.path, replace: result.replace } as const;
+          case "Forbidden": {
+            const component = dependencies.resolveForbidden(match);
+            return Option.isSome(component)
+              ? { _tag: "ForbiddenBoundary", component: component.value }
+              : noBoundary(request, "missing forbidden boundary", "forbidden");
+          }
+          case "Error": {
+            const component = dependencies.resolveError(match, result.cause);
+            return Option.isSome(component)
+              ? { _tag: "ErrorBoundary", component: component.value, cause: result.cause }
+              : noBoundary(request, "missing error boundary", result.cause);
+          }
+        }
+      }),
     };
   });
 


### PR DESCRIPTION
## Summary

- Extends `RouteActivationBoundary` to resolve error, not-found, forbidden, redirect, middleware, and no-boundary outcomes.
- Routes Outlet not-found, middleware redirect/forbidden/error, and decode error boundary selection through the activation boundary seam.
- Adds contract tests for nearest boundary intents, middleware redirect/forbidden intents, and no-boundary fallback behavior.

## DX impact

Before:

```ts
// Outlet selected middleware and boundary outcomes inline.
Route.make("/admin").forbidden(AdminForbidden)
```

After:

```ts
// Public route APIs are unchanged; outcome selection now flows through RouteActivationBoundary.
Route.make("/admin").forbidden(AdminForbidden)
```

## Acceptance criteria

From #234 / #218:

- [x] Error, not-found, and forbidden boundary selection flows through RouteActivationBoundary.
- [x] Middleware redirect and forbidden outcomes are represented through the activation/boundary contract.
- [x] Tests cover nearest error boundary, nearest not-found boundary, nearest forbidden boundary, redirect outcome, forbidden outcome, and no-boundary failure behavior.
- [x] Layout preservation across sibling route navigation remains externally unchanged.
- [x] No #187 component lifecycle/provision behavior is changed by this slice.

## Weird spots or spots that need attention

- Redirect intents include `replace` in addition to the ICD's `location` so existing middleware redirect semantics are preserved.
- `NoBoundary` remains an internal intent; Outlet maps it back to existing default text (`Error`, `403 - Forbidden`, `404 - Not Found`) to avoid external behavior changes.
- Provider and route-level Layer semantics are intentionally untouched.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. **#253** 👈 current
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->