### PR TITLE
feat(core): add build artifact planner

### DIFF
--- a/packages/core/src/vite/__tests__/build-artifact-planner.test.ts
+++ b/packages/core/src/vite/__tests__/build-artifact-planner.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { Cause, Effect, Exit } from "effect";
+import {
+  diagnosticCodes,
+  makeBuildArtifactPlanner,
+  type BuildArtifactPlanInput,
+} from "../build-artifact-planner.js";
+
+const planner = makeBuildArtifactPlanner({ failOnWarnings: false });
+
+const input = (overrides: Partial<BuildArtifactPlanInput>): BuildArtifactPlanInput => ({
+  output: "server",
+  platform: "node",
+  hasApi: false,
+  appDir: "app",
+  generatedDir: ".trygg",
+  ...overrides,
+});
+
+describe("BuildArtifactPlanner", () => {
+  it("allows server output for supported platforms", async () => {
+    const plan = await Effect.runPromise(planner.validateOutput(input({ output: "server" })));
+
+    expect(plan.mayProceed).toBe(true);
+    expect(plan.diagnostics).toEqual([]);
+  });
+
+  it("allows deploy-target-neutral static output", async () => {
+    const plan = await Effect.runPromise(
+      planner.validateOutput(input({ output: "static", platform: "node" })),
+    );
+
+    expect(plan.mayProceed).toBe(true);
+    expect(plan.diagnostics).toEqual([]);
+  });
+
+  it("allows Cloudflare static SPA output without API", async () => {
+    const plan = await Effect.runPromise(
+      planner.validateOutput(input({ output: "static", platform: "cloudflare" })),
+    );
+
+    expect(plan.mayProceed).toBe(true);
+    expect(plan.diagnostics).toEqual([]);
+  });
+
+  it("rejects Cloudflare server output", async () => {
+    const exit = await Effect.runPromiseExit(
+      planner.validateOutput(input({ output: "server", platform: "cloudflare" })),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.squash(exit.cause)).toMatchObject({
+        diagnostic: expect.objectContaining({ code: diagnosticCodes.cloudflareServerUnsupported }),
+      });
+    }
+  });
+
+  it("warns for static API on non-Cloudflare platforms", async () => {
+    const plan = await Effect.runPromise(
+      planner.validateOutput(input({ output: "static", platform: "bun", hasApi: true })),
+    );
+
+    expect(plan.mayProceed).toBe(true);
+    expect(plan.diagnostics).toEqual([
+      expect.objectContaining({
+        _tag: "Warning",
+        code: diagnosticCodes.staticApiWarning,
+      }),
+    ]);
+  });
+
+  it("errors for Cloudflare static API", async () => {
+    const exit = await Effect.runPromiseExit(
+      planner.validateOutput(input({ output: "static", platform: "cloudflare", hasApi: true })),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.squash(exit.cause)).toMatchObject({
+        diagnostic: expect.objectContaining({ code: diagnosticCodes.cloudflareStaticApiUnsupported }),
+      });
+    }
+  });
+});

--- a/packages/core/src/vite/build-artifact-planner.ts
+++ b/packages/core/src/vite/build-artifact-planner.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure build output validation planning for the trygg Vite plugin.
+ *
+ * @remarks
+ * BuildArtifactPlanner decides output/platform/API diagnostics as data before
+ * Vite hooks perform file I/O, nested builds, or artifact generation.
+ *
+ * @since 1.0.0
+ * @module trygg/vite/build-artifact-planner
+ */
+import { Data, Effect, Layer, Schema } from "effect";
+import * as Context from "effect/Context";
+import type { Output, Platform } from "../config.js";
+
+export type BuildOutputMode = Output;
+export type BuildPlatform = Platform;
+
+export interface BuildArtifactPlanInput {
+  readonly output: BuildOutputMode;
+  readonly platform: BuildPlatform;
+  readonly hasApi: boolean;
+  readonly appDir: string;
+  readonly generatedDir: string;
+}
+
+export type BuildPlanDiagnostic =
+  | { readonly _tag: "Warning"; readonly code: string; readonly message: string }
+  | { readonly _tag: "Error"; readonly code: string; readonly message: string };
+
+export interface BuildOutputValidationPlan {
+  readonly input: BuildArtifactPlanInput;
+  readonly diagnostics: ReadonlyArray<BuildPlanDiagnostic>;
+  readonly mayProceed: boolean;
+}
+
+export class InvalidBuildOutputCombination extends Data.TaggedError(
+  "InvalidBuildOutputCombination",
+)<{
+  readonly input: BuildArtifactPlanInput;
+  readonly diagnostic: BuildPlanDiagnostic;
+}> {}
+
+export const BuildArtifactPlannerConfigInput = Schema.Struct({
+  failOnWarnings: Schema.Boolean,
+});
+
+type BuildArtifactPlannerConfig = typeof BuildArtifactPlannerConfigInput.Type;
+
+export interface BuildArtifactPlannerShape {
+  readonly validateOutput: (
+    input: BuildArtifactPlanInput,
+  ) => Effect.Effect<BuildOutputValidationPlan, InvalidBuildOutputCombination>;
+}
+
+export const diagnosticCodes = {
+  cloudflareServerUnsupported: "TRYGG_BUILD_CLOUDFLARE_SERVER_UNSUPPORTED",
+  staticApiWarning: "TRYGG_BUILD_STATIC_API_WARNING",
+  cloudflareStaticApiUnsupported: "TRYGG_BUILD_CLOUDFLARE_STATIC_API_UNSUPPORTED",
+} as const;
+
+export const makeBuildArtifactPlanner = (
+  configInput: BuildArtifactPlannerConfig,
+): BuildArtifactPlannerShape => {
+  const config = BuildArtifactPlannerConfigInput.make(configInput);
+
+  return {
+    validateOutput: Effect.fn("BuildArtifactPlanner.validateOutput")(function* (input) {
+      const diagnostics: Array<BuildPlanDiagnostic> = [];
+
+      if (input.output === "server" && input.platform === "cloudflare") {
+        diagnostics.push({
+          _tag: "Error",
+          code: diagnosticCodes.cloudflareServerUnsupported,
+          message:
+            'Cloudflare server output is not supported yet. Use platform: "node" or platform: "bun" for output: "server".',
+        });
+      }
+
+      if (input.hasApi && input.output === "static" && input.platform === "cloudflare") {
+        diagnostics.push({
+          _tag: "Error",
+          code: diagnosticCodes.cloudflareStaticApiUnsupported,
+          message:
+            'app/api.ts is not supported with platform: "cloudflare" and output: "static". Use output: "server" for API routes.',
+        });
+      } else if (input.hasApi && input.output === "static") {
+        diagnostics.push({
+          _tag: "Warning",
+          code: diagnosticCodes.staticApiWarning,
+          message:
+            '⚠ API routes in app/api.ts will not be included in static build.\n  Deploy your API separately or use output: "server".',
+        });
+      }
+
+      const blocking = diagnostics.find(
+        (diagnostic) => diagnostic._tag === "Error" || config.failOnWarnings,
+      );
+      if (blocking !== undefined) {
+        return yield* new InvalidBuildOutputCombination({ input, diagnostic: blocking });
+      }
+
+      return { input, diagnostics, mayProceed: true };
+    }),
+  };
+};
+
+export class BuildArtifactPlanner extends Context.Service<
+  BuildArtifactPlanner,
+  BuildArtifactPlannerShape
+>()("trygg/BuildArtifactPlanner") {
+  static readonly layer = (
+    configInput: BuildArtifactPlannerConfig,
+  ): Layer.Layer<BuildArtifactPlanner> =>
+    Layer.succeed(BuildArtifactPlanner, makeBuildArtifactPlanner(configInput));
+}

--- a/packages/core/src/vite/plugin.ts
+++ b/packages/core/src/vite/plugin.ts
@@ -55,6 +55,11 @@ import {
   PluginBootstrapError as PluginBootstrapErrorImpl,
   PluginFileSystemError as PluginFileSystemErrorImpl,
 } from "./errors.js";
+import {
+  InvalidBuildOutputCombination,
+  makeBuildArtifactPlanner,
+  type BuildPlanDiagnostic,
+} from "./build-artifact-planner.js";
 // BunDevPlatformLive is loaded dynamically to avoid loading @effect/platform-bun in Node.js
 
 // =============================================================================
@@ -2136,7 +2141,7 @@ interface BuildOutputService {
   ) => Effect.Effect<void, PluginValidationError | PluginFileSystemError>;
   readonly closeBundle: (
     input: BuildOutputCloseInput,
-  ) => Effect.Effect<void, PluginFileSystemError>;
+  ) => Effect.Effect<void, PluginValidationError | PluginFileSystemError>;
 }
 
 interface BuildOutputDeps {
@@ -2167,102 +2172,110 @@ export const makeBuildOutput = ({
   fileSystem,
   files,
   serverPlatform,
-}: BuildOutputDeps): BuildOutputService => ({
-  buildStart: ({ appDir, generatedDir, config, output, platform }) =>
-    Effect.gen(function* () {
-      const paths = { appDir, generatedDir };
-      const apiPath = files.appApiPath(paths);
+}: BuildOutputDeps): BuildOutputService => {
+  const planner = makeBuildArtifactPlanner({ failOnWarnings: false });
+  const emitDiagnostic = (diagnostic: BuildPlanDiagnostic) =>
+    diagnostic._tag === "Warning" ? Effect.logWarning(diagnostic.message) : Effect.void;
+  const validatePlan = (input: {
+    readonly output: Output;
+    readonly platform: Platform;
+    readonly hasApi: boolean;
+    readonly appDir: string;
+    readonly generatedDir: string;
+  }) =>
+    planner.validateOutput(input).pipe(
+      Effect.tap((plan) => Effect.forEach(plan.diagnostics, emitDiagnostic, { discard: true })),
+      Effect.catchTag("InvalidBuildOutputCombination", (error: InvalidBuildOutputCombination) =>
+        Effect.fail(
+          PluginValidationError.invalidStructure(error.diagnostic.message, error.input.appDir),
+        ),
+      ),
+    );
 
-      yield* validateApiPlatform(apiPath, platform).pipe(
-        Effect.provideService(FileSystem.FileSystem, fileSystem),
-        Effect.tapError(logApiValidationError),
-      );
+  return {
+    buildStart: ({ appDir, generatedDir, config, output, platform }) =>
+      Effect.gen(function* () {
+        const paths = { appDir, generatedDir };
+        const apiPath = files.appApiPath(paths);
 
-      if (config.command !== "build") {
-        return;
-      }
-
-      if (output === "server" && platform === "cloudflare") {
-        return yield* PluginValidationError.invalidStructure(
-          'Cloudflare server output is not supported yet. Use platform: "node" or platform: "bun" for output: "server".',
-          appDir,
+        yield* validateApiPlatform(apiPath, platform).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.tapError(logApiValidationError),
         );
-      }
 
-      yield* files.writeBuildEntryFiles(paths, { output, platform });
+        if (config.command !== "build") {
+          return;
+        }
 
-      const hasApi = yield* files.appApiExists(paths);
-      if (hasApi && output === "static" && platform === "cloudflare") {
-        return yield* PluginValidationError.invalidStructure(
-          'app/api.ts is not supported with platform: "cloudflare" and output: "static". Use output: "server" for API routes.',
-          apiPath,
-        );
-      }
+        const hasApi = yield* files.appApiExists(paths);
+        yield* validatePlan({ appDir, generatedDir, output, platform, hasApi });
+        yield* files.writeBuildEntryFiles(paths, { output, platform });
+      }),
+    closeBundle: ({ appDir, generatedDir, config, output, platform }) =>
+      config.command !== "build"
+        ? Effect.void
+        : Effect.gen(function* () {
+            const paths = { appDir, generatedDir };
+            const hasApi = yield* files.appApiExists(paths);
+            yield* validatePlan({ appDir, generatedDir, output, platform, hasApi });
 
-      if (hasApi && output === "static") {
-        yield* Effect.logWarning(
-          '⚠ API routes in app/api.ts will not be included in static build.\n  Deploy your API separately or use output: "server".',
-        );
-      }
-    }),
-  closeBundle: ({ appDir, generatedDir, config, output, platform }) =>
-    config.command !== "build"
-      ? Effect.void
-      : output === "static" && platform === "cloudflare"
-        ? Effect.gen(function* () {
-            const internalShellDir = nodePath.join(config.root, "dist", GENERATED_DIR);
-            const internalShellPath = nodePath.join(internalShellDir, "index.html");
-            const publicShellPath = nodePath.join(config.root, "dist", "index.html");
-            const shell = yield* fileSystem.readFileString(internalShellPath).pipe(
-              Effect.mapError(
-                (cause) =>
-                  new PluginFileSystemError({
-                    operation: "read",
-                    path: internalShellPath,
-                    cause,
-                  }),
-              ),
-            );
-
-            yield* fileSystem.writeFileString(publicShellPath, shell).pipe(
-              Effect.mapError(
-                (cause) =>
-                  new PluginFileSystemError({
-                    operation: "write",
-                    path: publicShellPath,
-                    cause,
-                  }),
-              ),
-            );
-            yield* removeFileIfExists(internalShellPath).pipe(
-              Effect.provideService(FileSystem.FileSystem, fileSystem),
-            );
-            yield* fileSystem.remove(internalShellDir, { recursive: true }).pipe(
-              Effect.mapError(
-                (cause) =>
-                  new PluginFileSystemError({
-                    operation: "remove",
-                    path: internalShellDir,
-                    cause,
-                  }),
-              ),
-            );
-          })
-        : output !== "server"
-          ? Effect.void
-          : Effect.gen(function* () {
-              const paths = { appDir, generatedDir };
-              const serverEntryPath = yield* files
-                .writeProductionServerEntry(paths)
-                .pipe(Effect.provideService(ServerPlatform, serverPlatform));
-
-              yield* Effect.logInfo("Building production server...");
-              yield* buildServer(serverEntryPath, config);
-              yield* Effect.logInfo("Server build complete").pipe(
-                Effect.annotateLogs("style", "success"),
+            if (output === "static" && platform === "cloudflare") {
+              const internalShellDir = nodePath.join(config.root, "dist", GENERATED_DIR);
+              const internalShellPath = nodePath.join(internalShellDir, "index.html");
+              const publicShellPath = nodePath.join(config.root, "dist", "index.html");
+              const shell = yield* fileSystem.readFileString(internalShellPath).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new PluginFileSystemError({
+                      operation: "read",
+                      path: internalShellPath,
+                      cause,
+                    }),
+                ),
               );
-            }),
-});
+
+              yield* fileSystem.writeFileString(publicShellPath, shell).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new PluginFileSystemError({
+                      operation: "write",
+                      path: publicShellPath,
+                      cause,
+                    }),
+                ),
+              );
+              yield* removeFileIfExists(internalShellPath).pipe(
+                Effect.provideService(FileSystem.FileSystem, fileSystem),
+              );
+              yield* fileSystem.remove(internalShellDir, { recursive: true }).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new PluginFileSystemError({
+                      operation: "remove",
+                      path: internalShellDir,
+                      cause,
+                    }),
+                ),
+              );
+              return;
+            }
+
+            if (output !== "server") {
+              return;
+            }
+
+            const serverEntryPath = yield* files
+              .writeProductionServerEntry(paths)
+              .pipe(Effect.provideService(ServerPlatform, serverPlatform));
+
+            yield* Effect.logInfo("Building production server...");
+            yield* buildServer(serverEntryPath, config);
+            yield* Effect.logInfo("Server build complete").pipe(
+              Effect.annotateLogs("style", "success"),
+            );
+          }),
+  };
+};
 
 const viteServerBuild = (
   serverEntryPath: string,


### PR DESCRIPTION
## Summary

Adds a pure `BuildArtifactPlanner` validation seam for build output/platform/API diagnostics and routes the Vite build output hooks through that plan before writing build artifacts or invoking nested server builds.

## DX impact

Before, output/platform/API decisions lived directly inside Vite hook branches:

```ts
if (output === "server" && platform === "cloudflare") {
  return yield* PluginValidationError.invalidStructure(...)
}

if (hasApi && output === "static") {
  yield* Effect.logWarning(...)
}
```

After, tests and hooks can use a typed validation plan with stable diagnostic codes/messages:

```ts
const plan = yield* planner.validateOutput({
  output: "static",
  platform: "bun",
  hasApi: true,
  appDir,
  generatedDir,
})

for (const diagnostic of plan.diagnostics) {
  yield* Effect.logWarning(diagnostic.message)
}
```

## Acceptance criteria

- [x] BuildArtifactPlanner exists with `validateOutput` service shape compatible with #219.
- [x] Planner tests cover server output, static output, Cloudflare static SPA, Cloudflare server rejection, static API warning, and Cloudflare static API error.
- [x] Vite buildStart/closeBundle validation code consumes the validation plan instead of re-deciding output/platform combinations inline.
- [x] Diagnostics are targeted and include stable codes/messages suitable for tests.
- [x] Existing Vite plugin build output tests pass or are intentionally moved to planner-level assertions.

## Weird spots / attention needed

- `buildStart` still performs the existing Bun API source validation separately because that check is about API module platform imports, not output artifact planning.
- `closeBundle` now re-runs the planner so server-entry generation and Cloudflare static shell promotion share the same validation seam as `buildStart`.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/vite/__tests__/build-artifact-planner.test.ts src/vite/__tests__/plugin.test.ts`
- `bun run --cwd packages/core test`

Closes #235.
Refs #219.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. **#254** 👈 current
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->