### PR TITLE
feat(core): plan generated build artifacts

### DIFF
--- a/packages/core/src/vite/__tests__/generated-artifact-planner.test.ts
+++ b/packages/core/src/vite/__tests__/generated-artifact-planner.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import {
+  makeBuildArtifactPlanner,
+  makeGeneratedArtifactPlanner,
+  type BuildArtifactPlanInput,
+} from "../build-artifact-planner.js";
+
+const validationPlanner = makeBuildArtifactPlanner({ failOnWarnings: false });
+const artifactPlanner = makeGeneratedArtifactPlanner({ includeCleanupOperations: true });
+
+const input = (overrides: Partial<BuildArtifactPlanInput>): BuildArtifactPlanInput => ({
+  output: "server",
+  platform: "node",
+  hasApi: false,
+  appDir: "app",
+  generatedDir: ".trygg",
+  ...overrides,
+});
+
+const plan = (overrides: Partial<BuildArtifactPlanInput>) =>
+  Effect.gen(function* () {
+    const validation = yield* validationPlanner.validateOutput(input(overrides));
+    return yield* artifactPlanner.planArtifacts(validation);
+  });
+
+describe("GeneratedArtifactPlanner", () => {
+  it("plans static generated shell without Worker artifact for non-Cloudflare targets", async () => {
+    const artifactPlan = await Effect.runPromise(plan({ output: "static", platform: "node" }));
+
+    expect(artifactPlan.operations).toEqual([
+      expect.objectContaining({ _tag: "WriteFile", path: ".trygg/index.html" }),
+      { _tag: "RemoveFile", path: ".trygg/worker-entry.js" },
+    ]);
+  });
+
+  it("plans Cloudflare static SPA Worker artifact", async () => {
+    const artifactPlan = await Effect.runPromise(
+      plan({ output: "static", platform: "cloudflare" }),
+    );
+
+    expect(artifactPlan.operations).toEqual([
+      expect.objectContaining({ _tag: "WriteFile", path: ".trygg/index.html" }),
+      expect.objectContaining({ _tag: "WriteFile", path: ".trygg/worker-entry.js" }),
+    ]);
+  });
+
+  it("plans server output with cleanup and nested server build intent", async () => {
+    const artifactPlan = await Effect.runPromise(plan({ output: "server", platform: "bun" }));
+
+    expect(artifactPlan.operations).toEqual([
+      expect.objectContaining({ _tag: "WriteFile", path: ".trygg/index.html" }),
+      { _tag: "RemoveFile", path: ".trygg/worker-entry.js" },
+      { _tag: "RunNestedBuild", name: "production-server", configFile: ".trygg/server-entry.ts" },
+    ]);
+  });
+
+  it("renders operation summaries", async () => {
+    const artifactPlan = await Effect.runPromise(plan({ output: "server", platform: "node" }));
+    const summary = await Effect.runPromise(artifactPlanner.renderOperationSummary(artifactPlan));
+
+    expect(summary).toEqual([
+      "write .trygg/index.html",
+      "remove .trygg/worker-entry.js",
+      "run production-server from .trygg/server-entry.ts",
+    ]);
+  });
+});

--- a/packages/core/src/vite/build-artifact-planner.ts
+++ b/packages/core/src/vite/build-artifact-planner.ts
@@ -12,6 +12,40 @@ import { Data, Effect, Layer, Schema } from "effect";
 import * as Context from "effect/Context";
 import type { Output, Platform } from "../config.js";
 
+const generatedPath = (generatedDir: string, fileName: string): string =>
+  `${generatedDir.replace(/\/$/, "")}/${fileName}`;
+
+const generateHtmlTemplate = (): string => `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <script type="module" src="/.trygg/entry.tsx"></script>
+  </head>
+  <body></body>
+</html>`;
+
+const renderCloudflareStaticWorkerEntryModule = (): string =>
+  `export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const pathname = url.pathname;
+
+    if (pathname.includes(".") && !pathname.startsWith("/api/")) {
+      return env.ASSETS.fetch(request);
+    }
+
+    const assetResponse = await env.ASSETS.fetch(request);
+    if (assetResponse.status !== 404) {
+      return assetResponse;
+    }
+
+    return env.ASSETS.fetch(new Request(new URL("/index.html", request.url), request));
+  },
+};
+`;
+
 export type BuildOutputMode = Output;
 export type BuildPlatform = Platform;
 
@@ -112,4 +146,99 @@ export class BuildArtifactPlanner extends Context.Service<
     configInput: BuildArtifactPlannerConfig,
   ): Layer.Layer<BuildArtifactPlanner> =>
     Layer.succeed(BuildArtifactPlanner, makeBuildArtifactPlanner(configInput));
+}
+
+export type BuildArtifactOperation =
+  | { readonly _tag: "WriteFile"; readonly path: string; readonly contents: string }
+  | { readonly _tag: "RemoveFile"; readonly path: string }
+  | { readonly _tag: "RunNestedBuild"; readonly name: string; readonly configFile: string };
+
+export interface GeneratedArtifactPlan {
+  readonly validation: BuildOutputValidationPlan;
+  readonly operations: ReadonlyArray<BuildArtifactOperation>;
+  readonly diagnostics: ReadonlyArray<BuildPlanDiagnostic>;
+}
+
+export class BuildArtifactPlanningError extends Data.TaggedError("BuildArtifactPlanningError")<{
+  readonly operation: string;
+  readonly cause: unknown;
+}> {}
+
+export const GeneratedArtifactPlannerConfigInput = Schema.Struct({
+  includeCleanupOperations: Schema.Boolean,
+});
+
+type GeneratedArtifactPlannerConfig = typeof GeneratedArtifactPlannerConfigInput.Type;
+
+export interface GeneratedArtifactPlannerShape {
+  readonly planArtifacts: (
+    validation: BuildOutputValidationPlan,
+  ) => Effect.Effect<GeneratedArtifactPlan, BuildArtifactPlanningError>;
+  readonly renderOperationSummary: (
+    plan: GeneratedArtifactPlan,
+  ) => Effect.Effect<ReadonlyArray<string>>;
+}
+
+export const makeGeneratedArtifactPlanner = (
+  configInput: GeneratedArtifactPlannerConfig,
+): GeneratedArtifactPlannerShape => {
+  const config = GeneratedArtifactPlannerConfigInput.make(configInput);
+
+  return {
+    planArtifacts: Effect.fn("GeneratedArtifactPlanner.planArtifacts")(function* (validation) {
+      const { generatedDir, output, platform } = validation.input;
+      const workerPath = generatedPath(generatedDir, "worker-entry.js");
+      const operations: Array<BuildArtifactOperation> = [
+        {
+          _tag: "WriteFile",
+          path: generatedPath(generatedDir, "index.html"),
+          contents: generateHtmlTemplate(),
+        },
+      ];
+
+      if (output === "static" && platform === "cloudflare") {
+        operations.push({
+          _tag: "WriteFile",
+          path: workerPath,
+          contents: renderCloudflareStaticWorkerEntryModule(),
+        });
+      } else if (config.includeCleanupOperations) {
+        operations.push({ _tag: "RemoveFile", path: workerPath });
+      }
+
+      if (output === "server") {
+        operations.push({
+          _tag: "RunNestedBuild",
+          name: "production-server",
+          configFile: generatedPath(generatedDir, "server-entry.ts"),
+        });
+      }
+
+      return { validation, operations, diagnostics: validation.diagnostics };
+    }),
+    renderOperationSummary: Effect.fn("GeneratedArtifactPlanner.renderOperationSummary")(
+      function* (plan) {
+        return plan.operations.map((operation) => {
+          switch (operation._tag) {
+            case "WriteFile":
+              return `write ${operation.path}`;
+            case "RemoveFile":
+              return `remove ${operation.path}`;
+            case "RunNestedBuild":
+              return `run ${operation.name} from ${operation.configFile}`;
+          }
+        });
+      },
+    ),
+  };
+};
+
+export class GeneratedArtifactPlanner extends Context.Service<
+  GeneratedArtifactPlanner,
+  GeneratedArtifactPlannerShape
+>()("trygg/GeneratedArtifactPlanner") {
+  static readonly layer = (
+    configInput: GeneratedArtifactPlannerConfig,
+  ): Layer.Layer<GeneratedArtifactPlanner> =>
+    Layer.succeed(GeneratedArtifactPlanner, makeGeneratedArtifactPlanner(configInput));
 }

--- a/packages/core/src/vite/plugin.ts
+++ b/packages/core/src/vite/plugin.ts
@@ -58,7 +58,10 @@ import {
 import {
   InvalidBuildOutputCombination,
   makeBuildArtifactPlanner,
+  makeGeneratedArtifactPlanner,
+  type BuildArtifactOperation,
   type BuildPlanDiagnostic,
+  type GeneratedArtifactPlan,
 } from "./build-artifact-planner.js";
 // BunDevPlatformLive is loaded dynamically to avoid loading @effect/platform-bun in Node.js
 
@@ -1557,6 +1560,12 @@ interface PluginFilesService {
   readonly regenerateGeneratedRouteTypes: (
     paths: PluginFilePaths,
   ) => Effect.Effect<void, PluginFileSystemError>;
+  readonly writeClientEntryFiles: (
+    paths: PluginFilePaths,
+  ) => Effect.Effect<void, PluginFileSystemError>;
+  readonly executeArtifactOperations: (
+    operations: ReadonlyArray<BuildArtifactOperation>,
+  ) => Effect.Effect<void, PluginFileSystemError>;
   readonly writeBuildEntryFiles: (
     paths: PluginFilePaths,
     options: { readonly output: Output; readonly platform: Platform },
@@ -1730,6 +1739,48 @@ export const makePluginFilesLayer = (): Layer.Layer<PluginFiles, never, FileSyst
         writeGeneratedRouteTypes,
         regenerateGeneratedRouteTypes: (paths) =>
           writeRouteTypesWithLog(paths, "Regenerated routes.d.ts"),
+        writeClientEntryFiles: (paths) =>
+          Effect.gen(function* () {
+            const entryPath = generatedEntryPath(paths);
+            const hasEntry = yield* pathExists(entryPath);
+            const routesFile = yield* routesFilePath(paths);
+
+            if (!hasEntry || routesFile !== undefined) {
+              yield* writeEntryFile(paths);
+            }
+
+            yield* writeGeneratedRouteTypes(paths);
+          }),
+        executeArtifactOperations: (operations) =>
+          Effect.forEach(
+            operations,
+            (operation) => {
+              switch (operation._tag) {
+                case "WriteFile":
+                  return writeFileSafe(operation.path, operation.contents);
+                case "RemoveFile":
+                  return pathExists(operation.path).pipe(
+                    Effect.flatMap((exists) =>
+                      exists
+                        ? fs.remove(operation.path).pipe(
+                            Effect.mapError(
+                              (cause) =>
+                                new PluginFileSystemError({
+                                  operation: "remove",
+                                  path: operation.path,
+                                  cause,
+                                }),
+                            ),
+                          )
+                        : Effect.void,
+                    ),
+                  );
+                case "RunNestedBuild":
+                  return Effect.void;
+              }
+            },
+            { discard: true },
+          ),
         writeBuildEntryFiles: (paths, options) =>
           Effect.gen(function* () {
             const entryPath = generatedEntryPath(paths);
@@ -2174,6 +2225,7 @@ export const makeBuildOutput = ({
   serverPlatform,
 }: BuildOutputDeps): BuildOutputService => {
   const planner = makeBuildArtifactPlanner({ failOnWarnings: false });
+  const generatedArtifactPlanner = makeGeneratedArtifactPlanner({ includeCleanupOperations: true });
   const emitDiagnostic = (diagnostic: BuildPlanDiagnostic) =>
     diagnostic._tag === "Warning" ? Effect.logWarning(diagnostic.message) : Effect.void;
   const validatePlan = (input: {
@@ -2190,6 +2242,35 @@ export const makeBuildOutput = ({
           PluginValidationError.invalidStructure(error.diagnostic.message, error.input.appDir),
         ),
       ),
+    );
+  const planArtifacts = (input: {
+    readonly output: Output;
+    readonly platform: Platform;
+    readonly hasApi: boolean;
+    readonly appDir: string;
+    readonly generatedDir: string;
+  }) =>
+    Effect.gen(function* () {
+      const validation = yield* validatePlan(input);
+      return yield* generatedArtifactPlanner.planArtifacts(validation).pipe(
+        Effect.mapError((error) =>
+          PluginValidationError.invalidStructure(
+            `Failed to plan build artifacts during ${error.operation}`,
+            input.appDir,
+          ),
+        ),
+      );
+    });
+  const hasOperation = (
+    plan: GeneratedArtifactPlan,
+    tag: BuildArtifactOperation["_tag"],
+    path: string,
+  ) =>
+    plan.operations.some(
+      (operation) =>
+        operation._tag === tag &&
+        "path" in operation &&
+        nodePath.resolve(operation.path) === nodePath.resolve(path),
     );
 
   return {
@@ -2208,8 +2289,11 @@ export const makeBuildOutput = ({
         }
 
         const hasApi = yield* files.appApiExists(paths);
-        yield* validatePlan({ appDir, generatedDir, output, platform, hasApi });
-        yield* files.writeBuildEntryFiles(paths, { output, platform });
+        const artifactPlan = yield* planArtifacts({ appDir, generatedDir, output, platform, hasApi });
+        yield* files.writeClientEntryFiles(paths);
+        yield* files.executeArtifactOperations(
+          artifactPlan.operations.filter((operation) => operation._tag !== "RunNestedBuild"),
+        );
       }),
     closeBundle: ({ appDir, generatedDir, config, output, platform }) =>
       config.command !== "build"
@@ -2217,9 +2301,9 @@ export const makeBuildOutput = ({
         : Effect.gen(function* () {
             const paths = { appDir, generatedDir };
             const hasApi = yield* files.appApiExists(paths);
-            yield* validatePlan({ appDir, generatedDir, output, platform, hasApi });
+            const artifactPlan = yield* planArtifacts({ appDir, generatedDir, output, platform, hasApi });
 
-            if (output === "static" && platform === "cloudflare") {
+            if (hasOperation(artifactPlan, "WriteFile", nodePath.join(generatedDir, "worker-entry.js"))) {
               const internalShellDir = nodePath.join(config.root, "dist", GENERATED_DIR);
               const internalShellPath = nodePath.join(internalShellDir, "index.html");
               const publicShellPath = nodePath.join(config.root, "dist", "index.html");
@@ -2260,7 +2344,10 @@ export const makeBuildOutput = ({
               return;
             }
 
-            if (output !== "server") {
+            const nestedBuild = artifactPlan.operations.find(
+              (operation) => operation._tag === "RunNestedBuild" && operation.name === "production-server",
+            );
+            if (nestedBuild === undefined) {
               return;
             }
 


### PR DESCRIPTION
## Summary

Adds `GeneratedArtifactPlanner` on top of the build output validation plan so generated shell files, cleanup, Cloudflare Worker artifact intent, and nested server build intent are represented as data before filesystem execution.

## DX impact

Before, hooks encoded artifact decisions directly:

```ts
if (options.platform === "cloudflare" && options.output === "static") {
  yield* writeFileSafe(workerPath, renderCloudflareStaticWorkerEntryModule())
}
```

After, artifact operations are inspectable plan data and PluginFiles executes those operations:

```ts
const artifactPlan = yield* generatedArtifactPlanner.planArtifacts(validation)
yield* files.executeArtifactOperations(
  artifactPlan.operations.filter((operation) => operation._tag !== "RunNestedBuild"),
)
```

## Acceptance criteria

- [x] GeneratedArtifactPlanner exists with `planArtifacts` and `renderOperationSummary` behavior compatible with #220.
- [x] Plan operations cover write, remove/cleanup, and nested build intent where current build behavior requires them.
- [x] PluginFiles/Vite hooks execute the returned plan without re-deciding output/platform semantics.
- [x] Tests assert artifact plan data for static, Cloudflare static SPA, server output, cleanup, Worker artifact, and nested server build intent.
- [x] Existing filesystem-facing integration tests still verify execution without becoming the source of output-mode truth.

## Weird spots / attention needed

- Client entry and route type generation stays in `PluginFiles.writeClientEntryFiles` because that path still depends on routes-file discovery; this PR moves output/platform artifact decisions, not route scanning.
- `RunNestedBuild.configFile` points at the generated server-entry path. The actual server entry is still rendered by `PluginFiles.writeProductionServerEntry` so server platform rendering errors remain separate from planner data.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/vite/__tests__/build-artifact-planner.test.ts src/vite/__tests__/generated-artifact-planner.test.ts src/vite/__tests__/plugin.test.ts`
- `bun run --cwd packages/core test`

Closes #236.
Refs #220.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. **#255** 👈 current
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->