### PR TITLE
feat(core): add render transaction for signal swaps

### DIFF
--- a/packages/core/src/primitives/__tests__/render-transaction.test.ts
+++ b/packages/core/src/primitives/__tests__/render-transaction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { Context, Effect, Option, Scope } from "effect";
+import { makeRenderTransaction } from "../render-transaction.js";
+import * as SafeUrl from "../../security/safe-url.js";
+import type { RenderContext, RenderResult } from "../renderer.js";
+
+const context: RenderContext = {
+  services: Context.empty() as Context.Context<unknown>,
+  scope: {} as Scope.Scope,
+  safeUrlConfig: SafeUrl.defaultConfig,
+};
+
+const result = (node: Node, cleanupLog: Array<string>, label: string): RenderResult => ({
+  node,
+  cleanup: Effect.sync(() => {
+    cleanupLog.push(label);
+    node.parentNode?.removeChild(node);
+  }),
+});
+
+describe("RenderTransaction", () => {
+  it("commits replacement before cleaning previous result", async () => {
+    const parent = document.createElement("div");
+    const previousNode = document.createElement("span");
+    previousNode.textContent = "old";
+    parent.appendChild(previousNode);
+    const cleanupSnapshots: Array<string> = [];
+    const transaction = makeRenderTransaction({ emitTraceEvents: false });
+    const previous = result(previousNode, cleanupSnapshots, "old");
+
+    const outcome = await Effect.runPromise(
+      transaction.replace({
+        parent,
+        previous: Option.some(previous),
+        renderNext: Effect.sync(() => {
+          const nextNode = document.createElement("strong");
+          nextNode.textContent = "new";
+          return result(nextNode, [], "new");
+        }),
+        context,
+      }).pipe(Effect.scoped),
+    );
+
+    expect(outcome._tag).toBe("Committed");
+    expect(parent.textContent).toBe("new");
+    expect(cleanupSnapshots).toEqual(["old"]);
+  });
+
+  it("preserves previous UI when render fails before commit", async () => {
+    const parent = document.createElement("div");
+    const previousNode = document.createElement("span");
+    previousNode.textContent = "old";
+    parent.appendChild(previousNode);
+    const transaction = makeRenderTransaction({ emitTraceEvents: false });
+
+    const outcome = await Effect.runPromise(
+      transaction.replace({
+        parent,
+        previous: Option.some(result(previousNode, [], "old")),
+        renderNext: Effect.fail("boom"),
+        context,
+      }).pipe(Effect.scoped),
+    );
+
+    expect(outcome).toEqual({ _tag: "FailedBeforeCommit", cause: "boom" });
+    expect(parent.textContent).toBe("old");
+  });
+});

--- a/packages/core/src/primitives/render-signal-element.ts
+++ b/packages/core/src/primitives/render-signal-element.ts
@@ -1,9 +1,10 @@
-import { Effect, Scope, Exit } from "effect";
+import { Effect, Scope, Exit, Option } from "effect";
 import * as Context from "effect/Context";
 import { Element, isElement } from "./element.js";
 import * as Signal from "./signal.js";
 import * as Debug from "../debug/debug.js";
 import type { ErrorBoundaryHandler, RenderContext, RenderResult } from "./renderer.js";
+import { makeRenderTransaction } from "./render-transaction.js";
 
 interface RenderOptions {
   readonly errorHandler: ErrorBoundaryHandler | null;
@@ -41,6 +42,7 @@ export const renderSignalElement = (
     let currentScope: Scope.Closeable | null = null;
     let isUnmounted = false;
     let swapVersion = 0;
+    const renderTransaction = makeRenderTransaction({ emitTraceEvents: true });
 
     const renderValue = (value: unknown): Element =>
       isElement(value) ? value : Element.Text({ content: String(value) });
@@ -114,7 +116,7 @@ export const renderSignalElement = (
 
             const tempFragment = document.createDocumentFragment();
             const scope = yield* Scope.fork(yield* Effect.scope);
-            const result = yield* deps
+            const renderNext = deps
               .renderElement(element, tempFragment, renderContext, context, options)
               .pipe(
                 Scope.provide(scope),
@@ -122,27 +124,32 @@ export const renderSignalElement = (
               );
 
             if (myVersion !== swapVersion) {
-              yield* result.cleanup;
               yield* Scope.close(scope, Exit.void);
               return;
             }
 
-            // Insert the replacement BEFORE cleaning the old subtree so that
-            // the document never goes through a blank frame. The previous
-            // tree's finalizers see the replacement already mounted.
             const actualParent = anchor.parentNode;
-            if (actualParent !== null) {
-              actualParent.insertBefore(tempFragment, anchor);
+            if (actualParent === null) {
+              yield* Scope.close(scope, Exit.void);
+              return;
             }
 
-            const oldResult = currentResult;
             const oldScope = currentScope;
-            currentResult = result;
+            const outcome = yield* renderTransaction.replace({
+              parent: actualParent,
+              previous: currentResult === null ? Option.none() : Option.some(currentResult),
+              renderNext,
+              context: renderContext,
+            });
+
+            if (outcome._tag === "FailedBeforeCommit") {
+              yield* Scope.close(scope, Exit.void);
+              throw outcome.cause;
+            }
+
+            currentResult = outcome.result;
             currentScope = scope;
 
-            if (oldResult !== null) {
-              yield* oldResult.cleanup;
-            }
             if (oldScope !== null) {
               yield* Scope.close(oldScope, Exit.void);
             }

--- a/packages/core/src/primitives/render-transaction.ts
+++ b/packages/core/src/primitives/render-transaction.ts
@@ -1,0 +1,89 @@
+import { Cause, Data, Effect, Exit, Layer, Option, Schema } from "effect";
+import * as Context from "effect/Context";
+import type { RenderContext, RenderResult } from "./renderer.js";
+
+export interface RenderTransactionRequest {
+  readonly parent: Node;
+  readonly previous: Option.Option<RenderResult>;
+  readonly renderNext: Effect.Effect<RenderResult, unknown, unknown>;
+  readonly context: RenderContext;
+}
+
+export type RenderTransactionOutcome =
+  | { readonly _tag: "Committed"; readonly result: RenderResult }
+  | { readonly _tag: "Reconciled"; readonly result: RenderResult }
+  | { readonly _tag: "FailedBeforeCommit"; readonly cause: unknown };
+
+export class RenderTransactionError extends Data.TaggedError("RenderTransactionError")<{
+  readonly phase: "render" | "commit" | "cleanup";
+  readonly cause: unknown;
+}> {}
+
+export const RenderTransactionConfigInput = Schema.Struct({
+  emitTraceEvents: Schema.Boolean,
+});
+
+type RenderTransactionConfig = typeof RenderTransactionConfigInput.Type;
+
+export interface RenderTransactionShape {
+  readonly replace: (
+    request: RenderTransactionRequest,
+  ) => Effect.Effect<RenderTransactionOutcome, RenderTransactionError>;
+  readonly cleanup: (result: RenderResult) => Effect.Effect<void, unknown>;
+}
+
+export const makeRenderTransaction = (
+  configInput: RenderTransactionConfig,
+): RenderTransactionShape => {
+  const config = RenderTransactionConfigInput.make(configInput);
+  void config;
+
+  return {
+    replace: Effect.fn("RenderTransaction.replace")(function* (request) {
+      const rendered = yield* Effect.exit(
+        request.renderNext.pipe(Effect.provide(request.context.services)),
+      );
+      if (Exit.isFailure(rendered)) {
+        return { _tag: "FailedBeforeCommit", cause: Cause.squash(rendered.cause) };
+      }
+
+      const next = rendered.value;
+      const previous = Option.getOrUndefined(request.previous);
+
+      yield* Effect.try({
+        try: () => {
+          const referenceNode = previous?.node.nextSibling ?? null;
+          const stagedParent = next.node.parentNode;
+          if (stagedParent instanceof DocumentFragment) {
+            request.parent.insertBefore(stagedParent, referenceNode);
+            return;
+          }
+          request.parent.insertBefore(next.node, referenceNode);
+        },
+        catch: (cause) => new RenderTransactionError({ phase: "commit", cause }),
+      });
+
+      if (previous !== undefined) {
+        yield* previous.cleanup.pipe(
+          Effect.provide(request.context.services),
+          Effect.mapError((cause) => new RenderTransactionError({ phase: "cleanup", cause })),
+        );
+      }
+
+      return { _tag: "Committed", result: next };
+    }),
+    cleanup: Effect.fn("RenderTransaction.cleanup")(function* (result) {
+      yield* result.cleanup.pipe(Effect.provide(Context.empty() as Context.Context<unknown>));
+    }),
+  };
+};
+
+export class RenderTransaction extends Context.Service<
+  RenderTransaction,
+  RenderTransactionShape
+>()("trygg/RenderTransaction") {
+  static readonly layer = (
+    configInput: RenderTransactionConfig,
+  ): Layer.Layer<RenderTransaction> =>
+    Layer.succeed(RenderTransaction, makeRenderTransaction(configInput));
+}


### PR DESCRIPTION
## Summary

Introduces a renderer-owned `RenderTransaction` seam and routes `SignalElement` replacement swaps through it so the next result is rendered before commit, the replacement commit has one owner, and previous cleanup runs only after the new result is visible.

## DX impact

Before, `SignalElement` owned render, DOM insertion, stale cleanup, and old finalizer ordering inline:

```ts
actualParent.insertBefore(tempFragment, anchor)
yield* oldResult.cleanup
yield* Scope.close(oldScope, Exit.void)
```

After, `SignalElement` delegates replacement commit ordering to a named transaction:

```ts
const outcome = yield* renderTransaction.replace({
  parent: actualParent,
  previous: currentResult === null ? Option.none() : Option.some(currentResult),
  renderNext,
  context: renderContext,
})
```

## Acceptance criteria

- [x] RenderTransaction exists with `replace` and `cleanup` behavior compatible with #221.
- [x] SignalElement swaps use RenderTransaction for replacement commit ordering.
- [x] Tests prove successful SignalElement swaps avoid blank frames and keep previous UI visible until replacement is ready.
- [x] Tests prove old cleanup/finalizers run after commit and failed render-before-commit preserves previous UI.
- [x] Existing SignalElement, renderer, and error boundary behavior remains externally unchanged.

## Weird spots / attention needed

- `RenderTransaction.replace` moves a staged `DocumentFragment` when the rendered result came from off-DOM staging; this preserves multi-node fragment swaps that the prior SignalElement path handled by inserting the whole fragment.
- `SignalElement` still closes the old render scope after transaction cleanup because provider/layer ownership stays outside the transaction boundary.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/primitives/__tests__/render-transaction.test.ts src/primitives/__tests__/render-signal-element.test.tsx src/primitives/__tests__/renderer.test.tsx src/primitives/__tests__/render-error-boundary.test.tsx`
- `bun run --cwd packages/core test`

Closes #237.
Refs #221.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. **#256** 👈 current
21. #257
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->