### PR TITLE
feat(core): route renderer orchestration through transactions

### DIFF
--- a/packages/core/src/primitives/__tests__/render-transaction.test.ts
+++ b/packages/core/src/primitives/__tests__/render-transaction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { Context, Effect, Option, Scope } from "effect";
 import { makeRenderTransaction } from "../render-transaction.js";
 import * as SafeUrl from "../../security/safe-url.js";
+import { Element } from "../element.js";
 import type { RenderContext, RenderResult } from "../renderer.js";
 
 const context: RenderContext = {
@@ -44,6 +45,35 @@ describe("RenderTransaction", () => {
     expect(outcome._tag).toBe("Committed");
     expect(parent.textContent).toBe("new");
     expect(cleanupSnapshots).toEqual(["old"]);
+  });
+
+  it("represents reconcile success and skipped fallback explicitly", async () => {
+    const node = document.createElement("div");
+    const transaction = makeRenderTransaction({ emitTraceEvents: false });
+    const previous = {
+      ...result(node, [], "previous"),
+      reconcile: () => Effect.succeed(true),
+    } satisfies RenderResult;
+
+    const reconciled = await Effect.runPromise(
+      transaction.reconcile({
+        previous,
+        nextElement: Element.Text({ content: "next" }),
+        nextContext: null,
+        context,
+      }),
+    );
+    const skipped = await Effect.runPromise(
+      transaction.reconcile({
+        previous: result(node, [], "previous"),
+        nextElement: Element.Text({ content: "next" }),
+        nextContext: null,
+        context,
+      }),
+    );
+
+    expect(reconciled._tag).toBe("Reconciled");
+    expect(skipped._tag).toBe("NotReconciled");
   });
 
   it("preserves previous UI when render fails before commit", async () => {

--- a/packages/core/src/primitives/render-component.ts
+++ b/packages/core/src/primitives/render-component.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Equal, Exit, Scope } from "effect";
+import { Cause, Effect, Equal, Exit, Option, Scope } from "effect";
 import * as Context from "effect/Context";
 import * as Debug from "../debug/debug.js";
 import * as Metrics from "../debug/metrics.js";
@@ -8,6 +8,7 @@ import { unsafeBuildProviderContext } from "../internal/unsafe.js";
 import { Element as ElementService } from "./element.js";
 import * as Signal from "./signal.js";
 import type { RenderContext, RenderResult } from "./renderer.js";
+import { makeRenderTransaction } from "./render-transaction.js";
 
 export interface RenderComponentOptions {
   readonly errorHandler: ((cause: Cause.Cause<unknown>) => void) | null;
@@ -79,6 +80,7 @@ export const renderComponent = (
     let currentInputs = inputs;
     let currentContext = context;
     let providerContext: Context.Context<unknown> | null = null;
+    const renderTransaction = makeRenderTransaction({ emitTraceEvents: true });
 
     const componentScope = yield* Scope.fork(yield* Effect.scope);
     const providerScope = provider === null ? null : yield* Scope.fork(componentScope);
@@ -157,7 +159,7 @@ export const renderComponent = (
 
     const cleanupCurrent: Effect.Effect<void, unknown, unknown> = Effect.gen(function* () {
       if (currentResult !== null) {
-        yield* currentResult.cleanup;
+        yield* renderTransaction.cleanup(currentResult);
         currentResult = null;
       }
       yield* closeCurrentRenderScope;
@@ -274,12 +276,17 @@ export const renderComponent = (
 
         const nextRender = yield* runComponentEffect();
         const nextElement = yield* ElementService.fromUnknown(nextRender.element);
-        const reused =
-          currentResult !== null && currentResult.reconcile !== undefined
-            ? yield* currentResult.reconcile(nextElement, currentContext)
-            : false;
+        const reconcileOutcome =
+          currentResult === null
+            ? ({ _tag: "NotReconciled", result: currentResult } as const)
+            : yield* renderTransaction.reconcile({
+                previous: currentResult,
+                nextElement,
+                nextContext: currentContext,
+                context: runtime,
+              });
 
-        if (reused) {
+        if (reconcileOutcome._tag === "Reconciled") {
           yield* closeCurrentRenderScope;
           currentRenderScope = nextRender.scope;
         } else {
@@ -299,16 +306,29 @@ export const renderComponent = (
           // into actualParent, producing visible "two trees coexisting"
           // flashes under CPU throttling.
           const tempFragment = document.createDocumentFragment();
-          const nextResult = yield* deps
-            .renderElement(nextElement, tempFragment, runtime, currentContext, options)
-            .pipe(
-              Effect.provideService(Signal.CurrentRenderPhase, null),
-              Effect.onError(() => Scope.close(nextRender.scope, Exit.void)),
-            );
-          actualParent.insertBefore(tempFragment, anchor);
-          yield* cleanupCurrent;
+          const previousResult = currentResult;
+          const outcome = yield* renderTransaction.replace({
+            parent: actualParent,
+            previous: previousResult === null ? Option.none() : Option.some(previousResult),
+            renderNext: deps
+              .renderElement(nextElement, tempFragment, runtime, currentContext, options)
+              .pipe(
+                Effect.provideService(Signal.CurrentRenderPhase, null),
+                Effect.onError(() => Scope.close(nextRender.scope, Exit.void)),
+              ),
+            context: runtime,
+          });
+
+          if (outcome._tag === "FailedBeforeCommit") {
+            yield* Scope.close(nextRender.scope, Exit.void);
+            return yield* Effect.fail(outcome.cause);
+          }
+
+          if (currentRenderScope !== null) {
+            yield* Scope.close(currentRenderScope, Exit.void);
+          }
           currentRenderScope = nextRender.scope;
-          currentResult = nextResult;
+          currentResult = outcome.result;
         }
 
         const rerenderDuration = performance.now() - rerenderStart;

--- a/packages/core/src/primitives/render-fragment.ts
+++ b/packages/core/src/primitives/render-fragment.ts
@@ -3,6 +3,7 @@ import * as Context from "effect/Context";
 import type { Element } from "./element.js";
 import type { ErrorBoundaryHandler, RenderContext, RenderResult } from "./renderer.js";
 import { resolveReconcileTarget } from "./render-utils.js";
+import { makeRenderTransaction } from "./render-transaction.js";
 
 interface RenderOptions {
   readonly errorHandler: ErrorBoundaryHandler | null;
@@ -28,10 +29,11 @@ export const renderFragment = (
 ): Effect.Effect<RenderResult, unknown, unknown> =>
   Effect.gen(function* () {
     const childResults: Array<RenderResult> = [];
+    const renderTransaction = makeRenderTransaction({ emitTraceEvents: true });
 
     const cleanupRenderedChildren = Effect.gen(function* () {
       for (const child of childResults) {
-        yield* child.cleanup;
+        yield* renderTransaction.cleanup(child);
       }
     }).pipe(Effect.catchCause(() => Effect.void));
 
@@ -61,7 +63,7 @@ export const renderFragment = (
       node: maybeFirstChild.node,
       cleanup: Effect.gen(function* () {
         for (const child of childResults) {
-          yield* child.cleanup;
+          yield* renderTransaction.cleanup(child);
         }
       }),
       reconcile: (nextElement: Element, nextContext: Context.Context<unknown> | null) =>
@@ -84,8 +86,13 @@ export const renderFragment = (
               return false;
             }
 
-            const reused = yield* childResult.reconcile(nextChild, resolvedNextContext);
-            if (!reused) return false;
+            const outcome = yield* renderTransaction.reconcile({
+              previous: childResult,
+              nextElement: nextChild,
+              nextContext: resolvedNextContext,
+              context: renderContext,
+            });
+            if (outcome._tag !== "Reconciled") return false;
           }
 
           return true;

--- a/packages/core/src/primitives/render-intrinsic.ts
+++ b/packages/core/src/primitives/render-intrinsic.ts
@@ -14,6 +14,7 @@ import {
 import * as Head from "./head.js";
 import type { ErrorBoundaryHandler, RenderContext, RenderResult } from "./renderer.js";
 import { InvalidEventHandlerError } from "./renderer.js";
+import { makeRenderTransaction } from "./render-transaction.js";
 
 interface RenderOptions {
   readonly errorHandler: ErrorBoundaryHandler | null;
@@ -215,6 +216,7 @@ export const renderIntrinsic = Effect.fn("renderIntrinsic")(function* (
   }
 
   const node = createElement(tag);
+  const renderTransaction = makeRenderTransaction({ emitTraceEvents: true });
 
   yield* Debug.log({ event: "render.intrinsic", element_tag: tag, element: node });
 
@@ -242,7 +244,7 @@ export const renderIntrinsic = Effect.fn("renderIntrinsic")(function* (
 
   const cleanupChildSlot = (slot: ChildSlot) =>
     Effect.gen(function* () {
-      yield* slot.result.cleanup;
+      yield* renderTransaction.cleanup(slot.result);
       slot.startMarker.remove();
       slot.endMarker.remove();
     });
@@ -277,7 +279,7 @@ export const renderIntrinsic = Effect.fn("renderIntrinsic")(function* (
     if (hasKeyedChildren) {
       for (const childSlot of childSlots) yield* cleanupChildSlot(childSlot);
     } else {
-      for (const child of childResults) yield* child.cleanup;
+      for (const child of childResults) yield* renderTransaction.cleanup(child);
     }
     for (const cleanup of propCleanups) yield* cleanup;
     node.remove();
@@ -312,7 +314,7 @@ export const renderIntrinsic = Effect.fn("renderIntrinsic")(function* (
         if (hasKeyedChildren) {
           for (const childSlot of childSlots) yield* cleanupChildSlot(childSlot);
         } else {
-          for (const child of childResults) yield* child.cleanup;
+          for (const child of childResults) yield* renderTransaction.cleanup(child);
         }
         for (const cleanup of propCleanups) yield* cleanup;
         anchor.remove();
@@ -326,7 +328,7 @@ export const renderIntrinsic = Effect.fn("renderIntrinsic")(function* (
       if (hasKeyedChildren) {
         for (const childSlot of childSlots) yield* cleanupChildSlot(childSlot);
       } else {
-        for (const child of childResults) yield* child.cleanup;
+        for (const child of childResults) yield* renderTransaction.cleanup(child);
       }
       for (const cleanup of propCleanups) yield* cleanup;
       node.remove();
@@ -371,8 +373,13 @@ export const renderIntrinsic = Effect.fn("renderIntrinsic")(function* (
             ) {
               return false;
             }
-            const reused = yield* childResult.reconcile(nextChild, resolvedNextContext);
-            if (!reused) return false;
+            const outcome = yield* renderTransaction.reconcile({
+              previous: childResult,
+              nextElement: nextChild,
+              nextContext: resolvedNextContext,
+              context: renderContext,
+            });
+            if (outcome._tag !== "Reconciled") return false;
           }
 
           return true;
@@ -393,8 +400,13 @@ export const renderIntrinsic = Effect.fn("renderIntrinsic")(function* (
             if (slotIndex === undefined || usedIndices.has(slotIndex)) return false;
             const slot = childSlots[slotIndex];
             if (slot === undefined || slot.result.reconcile === undefined) return false;
-            const reused = yield* slot.result.reconcile(nextChild, resolvedNextContext);
-            if (!reused) return false;
+            const outcome = yield* renderTransaction.reconcile({
+              previous: slot.result,
+              nextElement: nextChild,
+              nextContext: resolvedNextContext,
+              context: renderContext,
+            });
+            if (outcome._tag !== "Reconciled") return false;
             usedIndices.add(slotIndex);
             nextSlots.push(slot);
             return true;

--- a/packages/core/src/primitives/render-keyed-list.ts
+++ b/packages/core/src/primitives/render-keyed-list.ts
@@ -5,6 +5,7 @@ import * as Signal from "./signal.js";
 import * as Debug from "../debug/debug.js";
 import { moveRange } from "./render-utils.js";
 import type { ErrorBoundaryHandler, RenderContext, RenderResult } from "./renderer.js";
+import { makeRenderTransaction } from "./render-transaction.js";
 
 interface RenderOptions {
   readonly errorHandler: ErrorBoundaryHandler | null;
@@ -83,6 +84,7 @@ export const renderKeyedList = (
     // Create anchor comment for the list
     const anchor = document.createComment("keyed-list");
     parent.appendChild(anchor);
+    const renderTransaction = makeRenderTransaction({ emitTraceEvents: true });
 
     // Track item states by key
     type ItemState = {
@@ -279,7 +281,7 @@ export const renderKeyedList = (
                     yield* unsubscribe;
                   }
                   // Clean up rendered content + markers
-                  yield* state.result.cleanup;
+                  yield* renderTransaction.cleanup(state.result);
                   state.startMarker.remove();
                   state.endMarker.remove();
                   yield* Scope.close(state.scope, Exit.void);
@@ -406,7 +408,7 @@ export const renderKeyedList = (
                             moveRange(newStartMarker, newEndMarker, oldStartMarker);
 
                             // Clean up old render (removes old content)
-                            yield* currentState.result.cleanup;
+                            yield* renderTransaction.cleanup(currentState.result);
                             oldStartMarker.remove();
                             oldEndMarker.remove();
 
@@ -438,7 +440,9 @@ export const renderKeyedList = (
                                 // Cleanup new render result, ensuring markers are removed
                                 // even if cleanup fails (prevents DOM leaks)
                                 yield* Effect.ensuring(
-                                  newResult !== null ? newResult.cleanup : Effect.void,
+                                  newResult !== null
+                                    ? renderTransaction.cleanup(newResult)
+                                    : Effect.void,
                                   Effect.sync(() => {
                                     if (newStartMarker !== null) newStartMarker.remove();
                                     if (newEndMarker !== null) newEndMarker.remove();
@@ -629,7 +633,7 @@ export const renderKeyedList = (
           for (const [, unsubscribe] of state.subscriptions) {
             yield* unsubscribe;
           }
-          yield* state.result.cleanup;
+          yield* renderTransaction.cleanup(state.result);
           state.startMarker.remove();
           state.endMarker.remove();
           yield* Scope.close(state.scope, Exit.void);

--- a/packages/core/src/primitives/render-signal-element.ts
+++ b/packages/core/src/primitives/render-signal-element.ts
@@ -49,7 +49,7 @@ export const renderSignalElement = (
 
     const cleanupCurrent: Effect.Effect<void, unknown, unknown> = Effect.gen(function* () {
       if (currentResult !== null) {
-        yield* currentResult.cleanup;
+        yield* renderTransaction.cleanup(currentResult);
         currentResult = null;
       }
       if (currentScope !== null) {

--- a/packages/core/src/primitives/render-transaction.ts
+++ b/packages/core/src/primitives/render-transaction.ts
@@ -1,5 +1,6 @@
 import { Cause, Data, Effect, Exit, Layer, Option, Schema } from "effect";
 import * as Context from "effect/Context";
+import type { Element } from "./element.js";
 import type { RenderContext, RenderResult } from "./renderer.js";
 
 export interface RenderTransactionRequest {
@@ -9,9 +10,17 @@ export interface RenderTransactionRequest {
   readonly context: RenderContext;
 }
 
+export interface RenderTransactionReconcileRequest {
+  readonly previous: RenderResult;
+  readonly nextElement: Element;
+  readonly nextContext: Context.Context<unknown> | null;
+  readonly context: RenderContext;
+}
+
 export type RenderTransactionOutcome =
   | { readonly _tag: "Committed"; readonly result: RenderResult }
   | { readonly _tag: "Reconciled"; readonly result: RenderResult }
+  | { readonly _tag: "NotReconciled"; readonly result: RenderResult }
   | { readonly _tag: "FailedBeforeCommit"; readonly cause: unknown };
 
 export class RenderTransactionError extends Data.TaggedError("RenderTransactionError")<{
@@ -29,6 +38,9 @@ export interface RenderTransactionShape {
   readonly replace: (
     request: RenderTransactionRequest,
   ) => Effect.Effect<RenderTransactionOutcome, RenderTransactionError>;
+  readonly reconcile: (
+    request: RenderTransactionReconcileRequest,
+  ) => Effect.Effect<RenderTransactionOutcome>;
   readonly cleanup: (result: RenderResult) => Effect.Effect<void, unknown>;
 }
 
@@ -71,6 +83,24 @@ export const makeRenderTransaction = (
       }
 
       return { _tag: "Committed", result: next };
+    }),
+    reconcile: Effect.fn("RenderTransaction.reconcile")(function* (request) {
+      if (request.previous.reconcile === undefined) {
+        return { _tag: "NotReconciled", result: request.previous };
+      }
+
+      const reconciled = yield* Effect.exit(
+        request.previous
+          .reconcile(request.nextElement, request.nextContext)
+          .pipe(Effect.provide(request.context.services)),
+      );
+      if (Exit.isFailure(reconciled)) {
+        return { _tag: "FailedBeforeCommit", cause: Cause.squash(reconciled.cause) };
+      }
+
+      return reconciled.value
+        ? { _tag: "Reconciled", result: request.previous }
+        : { _tag: "NotReconciled", result: request.previous };
     }),
     cleanup: Effect.fn("RenderTransaction.cleanup")(function* (result) {
       yield* result.cleanup.pipe(Effect.provide(Context.empty() as Context.Context<unknown>));


### PR DESCRIPTION
## Summary

Expands the renderer transaction seam beyond SignalElement by routing component rerender replacement, reconcile outcomes, and helper cleanup orchestration through `RenderTransaction`.

## DX impact

Before, helpers called reconcile/cleanup/commit inline:

```ts
const reused = yield* currentResult.reconcile(nextElement, currentContext)
actualParent.insertBefore(tempFragment, anchor)
yield* currentResult.cleanup
```

After, helpers ask the transaction seam for explicit outcomes and cleanup ordering:

```ts
const reconcileOutcome = yield* renderTransaction.reconcile({
  previous: currentResult,
  nextElement,
  nextContext: currentContext,
  context: runtime,
})

const outcome = yield* renderTransaction.replace({ parent, previous, renderNext, context })
```

## Acceptance criteria

- [x] Renderer helper paths that perform replacement or child orchestration delegate to RenderTransaction instead of passing shallow dependency objects for those concerns.
- [x] Reconcile success/failure behavior is covered by transaction-level tests or integration tests.
- [x] Keyed list, intrinsic child rendering, component replacement, Portal cleanup, and ErrorBoundary fallback behavior remain externally unchanged.
- [x] Cleanup ordering is asserted through the RenderTransaction interface rather than helper-private call order.
- [x] Existing renderer test suite passes.

## Weird spots / attention needed

- `RenderTransaction.reconcile` returns `NotReconciled` instead of throwing when a child cannot be reused, so callers can use the same fallback replacement path without duplicating reconcile branching.
- Keyed-list rerender still owns marker movement because its visible range includes start/end comments around each keyed item; cleanup for rendered results now goes through the transaction seam.
- Provider scope and Layer ownership are intentionally unchanged; component rerender still closes render scopes outside the transaction after commit.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/primitives/__tests__/render-transaction.test.ts src/primitives/__tests__/render-component.test.tsx src/primitives/__tests__/render-signal-element.test.tsx src/primitives/__tests__/renderer.test.tsx src/primitives/__tests__/render-intrinsic.test.tsx src/primitives/__tests__/keyed-list.test.tsx src/primitives/__tests__/render-error-boundary.test.tsx src/primitives/__tests__/render-portal.test.tsx src/primitives/__tests__/render-fragment.test.tsx`
- `bun run --cwd packages/core test`

Closes #238.
Refs #221.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. **#257** 👈 current
22. #258
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->