### PR TITLE
feat(core): preserve render context transactions

### DIFF
--- a/packages/core/src/primitives/__tests__/render-context-transaction.test.ts
+++ b/packages/core/src/primitives/__tests__/render-context-transaction.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { Context, Effect, Option, Scope } from "effect";
+import {
+  makeRenderContextTransaction,
+  type RenderContextSnapshot,
+} from "../render-context-transaction.js";
+import * as SafeUrl from "../../security/safe-url.js";
+import { unsafeWidenContext } from "../../internal/unsafe.js";
+
+class Message extends Context.Service<Message, { readonly value: string }>()("test/Message") {}
+
+const makeSnapshot = async (): Promise<RenderContextSnapshot> => {
+  const scope = await Effect.runPromise(Scope.make());
+  const services = unsafeWidenContext(Context.make(Message, { value: "root" }));
+  return { services, scope, safeUrlConfig: SafeUrl.defaultConfig };
+};
+
+describe("RenderContextTransaction", () => {
+  it("runs event handlers with the captured service context and scope", async () => {
+    const transaction = makeRenderContextTransaction({ emitLifecycleTraceEvents: false });
+    const snapshot = await makeSnapshot();
+
+    const value = await Effect.runPromise(
+      transaction.runEventHandler(
+        snapshot,
+        Effect.gen(function* () {
+          const message = yield* Message;
+          yield* Effect.addFinalizer(() => Effect.void);
+          return message.value;
+        }),
+      ),
+    );
+
+    expect(value).toBe("root");
+  });
+
+  it("forks and finalizes owned render scopes with additional services", async () => {
+    const transaction = makeRenderContextTransaction({ emitLifecycleTraceEvents: false });
+    const parent = await makeSnapshot();
+    const additional = unsafeWidenContext(Context.make(Message, { value: "child" }));
+
+    const child = await Effect.runPromise(
+      transaction.forkContext({
+        parent,
+        additionalServices: Option.some(additional),
+        scopeOwner: "component",
+      }),
+    );
+    const value = await Effect.runPromise(
+      transaction.runEventHandler(
+        child,
+        Effect.gen(function* () {
+          const message = yield* Message;
+          return message.value;
+        }),
+      ),
+    );
+
+    expect(value).toBe("child");
+    await Effect.runPromise(transaction.finalizeOwnedScope(child));
+  });
+});

--- a/packages/core/src/primitives/render-context-transaction.ts
+++ b/packages/core/src/primitives/render-context-transaction.ts
@@ -1,0 +1,76 @@
+import { Data, Effect, Exit, Layer, Option, Schema, Scope } from "effect";
+import * as Context from "effect/Context";
+import type { RenderContext } from "./renderer.js";
+
+export type RenderContextSnapshot = RenderContext;
+
+export interface RenderContextForkRequest {
+  readonly parent: RenderContextSnapshot;
+  readonly additionalServices: Option.Option<Context.Context<unknown>>;
+  readonly scopeOwner: "component" | "provider" | "signal" | "portal" | "boundary";
+}
+
+export class RenderContextOwnershipError extends Data.TaggedError("RenderContextOwnershipError")<{
+  readonly owner: RenderContextForkRequest["scopeOwner"];
+  readonly cause: unknown;
+}> {}
+
+export const RenderContextTransactionConfigInput = Schema.Struct({
+  emitLifecycleTraceEvents: Schema.Boolean,
+});
+
+type RenderContextTransactionConfig = typeof RenderContextTransactionConfigInput.Type;
+
+export interface RenderContextTransactionShape {
+  readonly forkContext: (
+    request: RenderContextForkRequest,
+  ) => Effect.Effect<RenderContextSnapshot, RenderContextOwnershipError>;
+  readonly runEventHandler: <A, E>(
+    snapshot: RenderContextSnapshot,
+    handler: Effect.Effect<A, E, unknown>,
+  ) => Effect.Effect<A, E>;
+  readonly finalizeOwnedScope: (snapshot: RenderContextSnapshot) => Effect.Effect<void, never>;
+}
+
+export const makeRenderContextTransaction = (
+  configInput: RenderContextTransactionConfig,
+): RenderContextTransactionShape => {
+  const config = RenderContextTransactionConfigInput.make(configInput);
+  void config;
+
+  return {
+    forkContext: Effect.fn("RenderContextTransaction.forkContext")(function* (request) {
+      const scope = yield* Scope.fork(request.parent.scope).pipe(
+        Effect.mapError(
+          (cause) => new RenderContextOwnershipError({ owner: request.scopeOwner, cause }),
+        ),
+      );
+      const services = Option.isSome(request.additionalServices)
+        ? Context.merge(request.parent.services, request.additionalServices.value)
+        : request.parent.services;
+
+      return {
+        services,
+        scope,
+        safeUrlConfig: request.parent.safeUrlConfig,
+      };
+    }),
+    runEventHandler: (snapshot, handler) =>
+      handler.pipe(Scope.provide(snapshot.scope), Effect.provide(snapshot.services)),
+    finalizeOwnedScope: Effect.fn("RenderContextTransaction.finalizeOwnedScope")(function* (
+      snapshot,
+    ) {
+      yield* Scope.close(snapshot.scope, Exit.void).pipe(Effect.orDie);
+    }),
+  };
+};
+
+export class RenderContextTransaction extends Context.Service<
+  RenderContextTransaction,
+  RenderContextTransactionShape
+>()("trygg/RenderContextTransaction") {
+  static readonly layer = (
+    configInput: RenderContextTransactionConfig,
+  ): Layer.Layer<RenderContextTransaction> =>
+    Layer.succeed(RenderContextTransaction, makeRenderContextTransaction(configInput));
+}

--- a/packages/core/src/primitives/render-intrinsic.ts
+++ b/packages/core/src/primitives/render-intrinsic.ts
@@ -14,6 +14,7 @@ import {
 import * as Head from "./head.js";
 import type { ErrorBoundaryHandler, RenderContext, RenderResult } from "./renderer.js";
 import { InvalidEventHandlerError } from "./renderer.js";
+import { makeRenderContextTransaction } from "./render-context-transaction.js";
 import { makeRenderTransaction } from "./render-transaction.js";
 
 interface RenderOptions {
@@ -107,6 +108,11 @@ const applyProps = Effect.fn("applyProps")(function* (
   deps: RenderIntrinsicDeps,
 ) {
   const cleanups: Array<Effect.Effect<void>> = [];
+  const contextTransaction = makeRenderContextTransaction({ emitLifecycleTraceEvents: true });
+  const eventSnapshot = {
+    ...renderContext,
+    services: context === null ? renderContext.services : Context.merge(context, renderContext.services),
+  };
 
   for (const [key, value] of Object.entries(props)) {
     if (value === undefined) continue;
@@ -118,7 +124,9 @@ const applyProps = Effect.fn("applyProps")(function* (
 
       const eventName = key.slice(2).toLowerCase();
       const listener = (event: Event) => {
-        deps.runForkInRenderContext(value(event), renderContext, context);
+        Effect.runForkWith(Context.empty())(
+          contextTransaction.runEventHandler(eventSnapshot, value(event)),
+        );
       };
       node.addEventListener(eventName, listener);
       cleanups.push(Effect.sync(() => node.removeEventListener(eventName, listener)));


### PR DESCRIPTION
## Summary

Adds `RenderContextTransaction` for render-time service context and scope preservation, and routes intrinsic event handler execution through the captured render snapshot.

## DX impact

Before, event props used helper-specific context plumbing directly:

```ts
const listener = (event: Event) => {
  deps.runForkInRenderContext(value(event), renderContext, context)
}
```

After, event execution is owned by the render context transaction contract:

```ts
const listener = (event: Event) => {
  Effect.runForkWith(Context.empty())(
    contextTransaction.runEventHandler(eventSnapshot, value(event)),
  )
}
```

## Acceptance criteria

- [x] RenderContextTransaction exists with `forkContext`, `runEventHandler`, and `finalizeOwnedScope` behavior compatible with #222.
- [x] Event handlers run under the render-time captured service context and scope.
- [x] Tests cover event handler captured context and owned scope finalization; existing provider scope cleanup, signal swap cleanup, Portal cleanup, and ErrorBoundary context preservation tests remain passing.
- [x] Shallow helper-specific context passing is replaced where RenderContextTransaction owns the behavior.
- [x] #187 component lifecycle/provision tests and #189/#190/#191/#192 expectations remain valid via the existing renderer/component suite.

## Weird spots / attention needed

- `forkContext` merges additional services over the parent snapshot to preserve provider shadowing behavior.
- This PR intentionally does not change `.provide(layer)`, provider scope ownership, or signal lifecycle semantics; it only centralizes context/scope capture and event handler execution.
- Intrinsic signal prop subscriptions still use the existing fork helper because this slice is focused on event handler capture and the RenderContextTransaction contract.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/primitives/__tests__/render-context-transaction.test.ts src/primitives/__tests__/render-intrinsic.test.tsx src/primitives/__tests__/renderer.test.tsx src/primitives/__tests__/render-component.test.tsx src/primitives/__tests__/render-signal-element.test.tsx src/primitives/__tests__/render-portal.test.tsx src/primitives/__tests__/render-error-boundary.test.tsx`
- `bun run --cwd packages/core test`

Closes #239.
Refs #222.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. **#258** 👈 current
23. #259
24. #260
25. #261
26. #262
<!-- stack:links:end -->