### PR TITLE
feat(core): trace navigation core semantics

### DIFF
--- a/packages/core/src/contract/trace.docs.md
+++ b/packages/core/src/contract/trace.docs.md
@@ -24,6 +24,15 @@ Events:
 - `history.forward`
 - `prefetch.trigger`
 
+Stable payload fields:
+
+- `operation`: `push`, `replace`, `back`, `forward`, or `refresh`.
+- `url`: resolved navigation URL for push/replace requests and history writes.
+- `patternOrPath`: original route pattern or path supplied to push/replace requests.
+- `replace`: boolean replacement intent for push/replace requests.
+- `previous` / `next`: committed **Current route** snapshots with `path`, `query`, `hash`, `scrollKey`, and `isPopstate`.
+- `previousQuery` / `nextQuery`: canonical query strings for query changes.
+
 Ordering guarantees:
 
 1. `router.navigate.request` is emitted before a Router-owned navigation writes history or commits the **Current route**.

--- a/packages/core/src/router/__tests__/navigation-core.test.ts
+++ b/packages/core/src/router/__tests__/navigation-core.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest";
 import { Effect, Ref } from "effect";
+import * as ContractTrace from "../../contract/trace.js";
 import * as Signal from "../../primitives/signal.js";
 import {
   NavigationCoreError,
@@ -56,6 +57,19 @@ const makeBrowserLikeCore = (initialPath: string): Effect.Effect<NavigationCoreS
     };
     return yield* makeNavigationCore({ notifyUnchangedQuery: false }, adapter).pipe(Effect.orDie);
   });
+
+const traceEventsFor = <E>(
+  effect: Effect.Effect<void, E>,
+): Effect.Effect<ReadonlyArray<ContractTrace.ContractTraceRecord>, E> =>
+  Effect.gen(function* () {
+    const collector = yield* ContractTrace.createInMemoryCollector("navigation-core");
+    yield* ContractTrace.withCollector(effect, collector);
+    return yield* collector.snapshot;
+  });
+
+const eventNames = (
+  records: ReadonlyArray<ContractTrace.ContractTraceRecord>,
+): ReadonlyArray<ContractTrace.ContractTraceEventName> => records.map((record) => record.event.event);
 
 const runNavigationLaws = (name: string, make: () => Effect.Effect<NavigationCoreShape>): void => {
   describe(name, () => {
@@ -134,6 +148,107 @@ runNavigationLaws("NavigationCore in-memory laws", () => makeCore("/dashboard?ta
 runNavigationLaws("NavigationCore browser-like adapter laws", () =>
   makeBrowserLikeCore("/dashboard?tab=main"),
 );
+
+describe("NavigationCore semantic traces", () => {
+  it.effect("orders push and replace request, history, state, query, and commit events", () =>
+    Effect.gen(function* () {
+      const records = yield* traceEventsFor(
+        Effect.gen(function* () {
+          const core = yield* makeCore("/dashboard?tab=main");
+          yield* core.navigate(navigationTarget("/users", { query: { tab: "details" } }));
+          yield* core.navigate(navigationTarget("/users", { query: { tab: "settings" }, replace: true }));
+        }),
+      );
+
+      assert.deepStrictEqual(eventNames(records), [
+        "router.navigate.request",
+        "history.push",
+        "router.current.set",
+        "router.query.set",
+        "router.navigate.commit",
+        "router.navigate.request",
+        "history.replace",
+        "router.query.set",
+        "router.navigate.commit",
+      ]);
+
+      assert.strictEqual(records[0]?.event.payload?.operation, "push");
+      assert.strictEqual(records[5]?.event.payload?.operation, "replace");
+    }),
+  );
+
+  it.effect("orders back and forward traces after adapter history movement", () =>
+    Effect.gen(function* () {
+      const records = yield* traceEventsFor(
+        Effect.gen(function* () {
+          const core = yield* makeCore("/dashboard");
+          yield* core.navigate(navigationTarget("/first"));
+          yield* core.navigate(navigationTarget("/second"));
+          yield* core.back;
+          yield* core.forward;
+        }),
+      );
+      const backStart = eventNames(records).indexOf("history.back");
+      const forwardStart = eventNames(records).indexOf("history.forward");
+
+      assert.deepStrictEqual(eventNames(records).slice(backStart - 1, backStart + 3), [
+        "router.navigate.request",
+        "history.back",
+        "router.current.set",
+        "router.navigate.commit",
+      ]);
+      assert.deepStrictEqual(eventNames(records).slice(forwardStart - 1, forwardStart + 3), [
+        "router.navigate.request",
+        "history.forward",
+        "router.current.set",
+        "router.navigate.commit",
+      ]);
+    }),
+  );
+
+  it.effect("suppresses unchanged query trace events", () =>
+    Effect.gen(function* () {
+      const records = yield* traceEventsFor(
+        Effect.gen(function* () {
+          const core = yield* makeCore("/dashboard?tab=main");
+          yield* core.navigate(navigationTarget("/dashboard", { query: { tab: "main" } }));
+        }),
+      );
+
+      assert.deepStrictEqual(eventNames(records), [
+        "router.navigate.request",
+        "history.push",
+        "router.navigate.commit",
+      ]);
+    }),
+  );
+
+  it.effect("does not emit commit traces when adapter navigation fails", () =>
+    Effect.gen(function* () {
+      const adapter: NavigationAdapter = {
+        read: Effect.succeed({
+          path: "/dashboard",
+          query: new URLSearchParams(),
+          isPopstate: false,
+          hash: "",
+          scrollKey: "failing-0",
+        }),
+        push: () => Effect.fail(new NavigationCoreError({ operation: "push", cause: "boom" })),
+        replace: () => Effect.void,
+        back: Effect.void,
+        forward: Effect.void,
+      };
+      const core = yield* makeNavigationCore({ notifyUnchangedQuery: false }, adapter).pipe(
+        Effect.orDie,
+      );
+      const records = yield* traceEventsFor(
+        core.navigate(navigationTarget("/broken")).pipe(Effect.result, Effect.asVoid),
+      );
+
+      assert.deepStrictEqual(eventNames(records), ["router.navigate.request"]);
+    }),
+  );
+});
 
 describe("Router.testLayer NavigationCore delegation", () => {
   it.effect("does not notify query subscribers when the semantic query is unchanged", () =>

--- a/packages/core/src/router/navigation-core.ts
+++ b/packages/core/src/router/navigation-core.ts
@@ -12,6 +12,7 @@
  */
 import { Data, Effect, Layer, Option, Schema, SynchronizedRef } from "effect";
 import * as Context from "effect/Context";
+import * as ContractTrace from "../contract/trace.js";
 import { interpolateParams } from "./types.js";
 import { buildPath, parsePath } from "./utils.js";
 
@@ -48,6 +49,62 @@ export const NavigationCoreConfigInput = Schema.Struct({
 });
 
 type NavigationCoreConfig = typeof NavigationCoreConfigInput.Type;
+
+type NavigationOperation = "push" | "replace" | "back" | "forward" | "refresh";
+
+const queryString = (query: URLSearchParams): string => query.toString();
+
+const snapshotPayload = (snapshot: NavigationSnapshot): Record<string, unknown> => ({
+  path: snapshot.path,
+  query: queryString(snapshot.query),
+  hash: snapshot.hash,
+  scrollKey: snapshot.scrollKey,
+  isPopstate: snapshot.isPopstate,
+});
+
+const emitNavigationTrace = (
+  event: ContractTrace.ContractTraceEventName,
+  payload: Record<string, unknown>,
+): Effect.Effect<void> =>
+  ContractTrace.emit({ event, level: "semantic", payload }).pipe(Effect.ignore);
+
+const historyEventFor = (
+  operation: Exclude<NavigationOperation, "refresh">,
+): ContractTrace.ContractTraceEventName => {
+  switch (operation) {
+    case "push":
+      return "history.push";
+    case "replace":
+      return "history.replace";
+    case "back":
+      return "history.back";
+    case "forward":
+      return "history.forward";
+  }
+};
+
+const emitSnapshotChanges = (
+  operation: NavigationOperation,
+  previous: NavigationSnapshot,
+  next: NavigationSnapshot,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    if (previous.path !== next.path || previous.hash !== next.hash) {
+      yield* emitNavigationTrace("router.current.set", {
+        operation,
+        previous: snapshotPayload(previous),
+        next: snapshotPayload(next),
+      });
+    }
+
+    if (!sameQuery(previous.query, next.query)) {
+      yield* emitNavigationTrace("router.query.set", {
+        operation,
+        previousQuery: queryString(previous.query),
+        nextQuery: queryString(next.query),
+      });
+    }
+  });
 
 export interface NavigationCoreShape {
   readonly current: Effect.Effect<NavigationSnapshot>;
@@ -104,26 +161,52 @@ export const makeNavigationCore = (
 
     const refresh = SynchronizedRef.updateEffect(state, () => adapter.read);
 
+    const commitSnapshot = (operation: NavigationOperation): Effect.Effect<NavigationSnapshot, NavigationCoreError> =>
+      Effect.gen(function* () {
+        const previous = yield* SynchronizedRef.get(state);
+        yield* refresh;
+        const next = yield* SynchronizedRef.get(state);
+        yield* emitSnapshotChanges(operation, previous, next);
+        yield* emitNavigationTrace("router.navigate.commit", {
+          operation,
+          previous: snapshotPayload(previous),
+          next: snapshotPayload(next),
+        });
+        return next;
+      });
+
     return {
       current: SynchronizedRef.get(state),
       navigate: Effect.fn("NavigationCore.navigate")(function* (target) {
         const url = yield* resolveNavigationTarget(target);
+        const operation = target.replace ? "replace" : "push";
         const historyState = { _scrollKey: `memory-${Date.now().toString(36)}` };
+        yield* emitNavigationTrace("router.navigate.request", {
+          operation,
+          url,
+          replace: target.replace,
+          patternOrPath: target.patternOrPath,
+        });
         if (target.replace) {
           yield* adapter.replace(url, historyState);
         } else {
           yield* adapter.push(url, historyState);
         }
-        yield* refresh;
+        yield* emitNavigationTrace(historyEventFor(operation), { operation, url });
+        yield* commitSnapshot(operation);
         void config;
       }),
       back: Effect.gen(function* () {
+        yield* emitNavigationTrace("router.navigate.request", { operation: "back" });
         yield* adapter.back;
-        yield* refresh;
+        yield* emitNavigationTrace("history.back", { operation: "back" });
+        yield* commitSnapshot("back");
       }).pipe(Effect.withSpan("NavigationCore.back")),
       forward: Effect.gen(function* () {
+        yield* emitNavigationTrace("router.navigate.request", { operation: "forward" });
         yield* adapter.forward;
-        yield* refresh;
+        yield* emitNavigationTrace("history.forward", { operation: "forward" });
+        yield* commitSnapshot("forward");
       }).pipe(Effect.withSpan("NavigationCore.forward")),
       isActive: Effect.fn("NavigationCore.isActive")(function* (target, exact) {
         const url = yield* resolveNavigationTarget(target);
@@ -133,7 +216,7 @@ export const makeNavigationCore = (
         const snapshot = yield* SynchronizedRef.get(state);
         return exact ? snapshot.path === path : snapshot.path.startsWith(path);
       }),
-      refresh,
+      refresh: commitSnapshot("refresh").pipe(Effect.asVoid),
     };
   });
 


### PR DESCRIPTION
## Summary

Adds verifier-facing semantic trace emissions at the `NavigationCore` ownership seam for navigation requests, history intents, committed route/query state changes, and navigation commits. Also documents the stable navigation trace payload fields introduced here.

## DX impact

Before, behavior contracts could observe navigation only indirectly through adapter state:

```ts
yield* core.navigate(navigationTarget("/users", { query: { tab: "details" } }))
assert.strictEqual((yield* core.current).path, "/users")
```

After, contracts can assert semantic navigation ordering without depending on private adapter/helper call order:

```ts
assert.deepStrictEqual(eventNames(records), [
  "router.navigate.request",
  "history.push",
  "router.current.set",
  "router.query.set",
  "router.navigate.commit",
])
```

## Acceptance criteria

- [x] NavigationCore emits semantic trace events at documented request/commit/query seams.
- [x] Behavior-contract tests assert navigation event ordering for push, replace, back, forward, changed query, and unchanged query suppression.
- [x] Trace payloads use domain terms and stable fields documented by #223.
- [x] Trace emission failures do not alter app behavior.
- [x] Existing navigation behavior remains unchanged outside verifier-facing traces.

## Weird spots / attention needed

- `ContractTrace.emit` remains no-op by default; these traces appear only when a contract runner/test provides a collector.
- Unchanged query navigations still emit request/history/commit events, but intentionally suppress `router.query.set` so contracts can distinguish navigation churn from semantic query changes.
- Adapter failures emit the request event but not history/commit events, preserving the failure boundary without pretending a navigation committed.

## Validation

- `bun run --cwd packages/core docs:check`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/router/__tests__/navigation-core.test.ts src/contract/__tests__/trace.test.ts`
- `bun run --cwd packages/core test`

Closes #241.
Refs #215.
Refs #223.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. **#260** 👈 current
25. #261
26. #262
<!-- stack:links:end -->