### PR TITLE
feat(core): trace route activation semantics

### DIFF
--- a/packages/core/src/contract/trace.docs.md
+++ b/packages/core/src/contract/trace.docs.md
@@ -52,6 +52,7 @@ Events:
 - `outlet.lazyLeaf.load.error`
 - `outlet.match.found`
 - `outlet.match.notFound`
+- `outlet.boundary.resolve`
 - `route.leaf.mount`
 - `route.leaf.unmount`
 - `route.render.skipStale`
@@ -62,9 +63,10 @@ Ordering guarantees:
 
 1. `outlet.process.start` begins one Outlet attempt to render the active **Route** tree from the **Routes manifest**.
 2. Lazy leaf events are ordered as `outlet.lazyLeaf.load.start` followed by either `outlet.lazyLeaf.load.ready` or `outlet.lazyLeaf.load.error` for the same activation.
-3. `outlet.process.dropStale`, `route.render.skipStale`, and `route.layout.skipStale` mean a newer activation won; they must happen before any stale visible commit.
-4. `outlet.process.commit` is emitted only after the activation selected by RouteActivation becomes the visible route content.
-5. `route.leaf.unmount` and `route.finalizer.run` belong to cleanup of the previously visible route tree and occur after the replacement commit that makes cleanup safe.
+3. `outlet.boundary.resolve` records loading, error, not-found, forbidden, redirect, no-boundary, and middleware outcomes selected for an activation.
+4. `outlet.process.dropStale`, `route.render.skipStale`, and `route.layout.skipStale` mean a newer activation won; they must happen before any stale visible commit.
+5. `outlet.process.commit` is emitted only after the activation selected by RouteActivation becomes the visible route content.
+6. `route.leaf.unmount` and `route.finalizer.run` belong to cleanup of the previously visible route tree and occur after the replacement commit that makes cleanup safe.
 
 ### Render transaction family
 

--- a/packages/core/src/contract/trace.ts
+++ b/packages/core/src/contract/trace.ts
@@ -38,6 +38,7 @@ export type ContractTraceEventName =
   | "outlet.lazyLeaf.load.error"
   | "outlet.match.found"
   | "outlet.match.notFound"
+  | "outlet.boundary.resolve"
   | "route.leaf.mount"
   | "route.leaf.unmount"
   | "route.render.skipStale"

--- a/packages/core/src/router/__tests__/route-activation.test.ts
+++ b/packages/core/src/router/__tests__/route-activation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Effect, Option, Ref } from "effect";
+import * as ContractTrace from "../../contract/trace.js";
 import { unsafeEraseR } from "../../internal/unsafe.js";
 import type { RouteMatch, RouteMatcherShape } from "../matching.js";
 import { makeRouteActivation, makeRouteActivationBoundary } from "../route-activation.js";
@@ -29,6 +30,19 @@ const makeMatcher = (matchPath: string, match: RouteMatch = makeMatch(matchPath)
   routes: Effect.succeed([]),
   match: (path) => Effect.succeed(path === matchPath ? Option.some(match) : Option.none()),
 });
+
+const traceEventsFor = <E, R>(
+  effect: Effect.Effect<void, E, R>,
+): Effect.Effect<ReadonlyArray<ContractTrace.ContractTraceRecord>, E, R> =>
+  Effect.gen(function* () {
+    const collector = yield* ContractTrace.createInMemoryCollector("route-activation");
+    yield* ContractTrace.withCollector(effect, collector);
+    return yield* collector.snapshot;
+  });
+
+const eventNames = (
+  records: ReadonlyArray<ContractTrace.ContractTraceRecord>,
+): ReadonlyArray<ContractTrace.ContractTraceEventName> => records.map((record) => record.event.event);
 
 const makeBoundary = (overrides: Partial<Parameters<typeof makeRouteActivationBoundary>[1]> = {}) =>
   makeRouteActivationBoundary(
@@ -435,6 +449,107 @@ describe("RouteActivation", () => {
     );
 
     expect(intent._tag).toBe("NoBoundary");
+  });
+
+  it("emits latest-route-wins activation traces", async () => {
+    const records = await Effect.runPromise(
+      unsafeEraseR(
+        traceEventsFor(
+          Effect.gen(function* () {
+            const activation = yield* makeRouteActivation(
+              { emitTraceEvents: true },
+              makeMatcher("/fast"),
+            );
+            yield* activation.activate(request("nav-1", "/slow")).pipe(Effect.result);
+            yield* activation.activate(request("nav-2", "/fast")).pipe(Effect.orDie);
+            yield* activation.commitAfterDomSwap(
+              { activationId: "nav-1", path: "/slow" },
+              Effect.void,
+              Effect.void,
+            );
+          }),
+        ),
+      ),
+    );
+
+    expect(eventNames(records)).toEqual([
+      "outlet.process.start",
+      "outlet.match.notFound",
+      "outlet.process.start",
+      "outlet.match.found",
+      "outlet.process.dropStale",
+    ]);
+    expect(records[4]?.event.payload).toMatchObject({
+      activationId: "nav-1",
+      path: "/slow",
+      supersededBy: "nav-2",
+    });
+  });
+
+  it("emits lazy load and boundary outcome traces", async () => {
+    const loaded = Effect.succeed({ _tag: "Text", value: "Lazy" }) as unknown as RouteComponent;
+    const loader = (() => Promise.resolve({ default: loaded })) as ComponentInput;
+    const loading = Effect.succeed({ _tag: "Text", value: "Loading" }) as unknown as ComponentInput;
+    const match = makeMatch("/lazy", { component: loader, loading });
+    const records = await Effect.runPromise(
+      unsafeEraseR(
+        traceEventsFor(
+          Effect.gen(function* () {
+            const boundary = yield* makeBoundary({
+              isComponentLoader: (component) => component === loader,
+              loadComponent: () => Effect.succeed(loaded),
+              resolveLoading: () => Option.some(loading),
+            });
+            yield* boundary.resolve(request("nav-1", "/lazy"), match);
+            yield* boundary.loadComponent(request("nav-1", "/lazy"), loader);
+            yield* boundary.resolveErrorBoundary(request("nav-1", "/lazy"), match, "boom");
+          }),
+        ),
+      ),
+    );
+
+    expect(eventNames(records)).toEqual([
+      "outlet.boundary.resolve",
+      "outlet.lazyLeaf.load.start",
+      "outlet.lazyLeaf.load.ready",
+      "outlet.boundary.resolve",
+    ]);
+    expect(records[0]?.event.payload).toMatchObject({
+      activationId: "nav-1",
+      path: "/lazy",
+      phase: "render",
+      outcome: "Loading",
+    });
+    expect(records[3]?.event.payload).toMatchObject({
+      phase: "error",
+      outcome: "NoBoundary",
+    });
+  });
+
+  it("emits commit and scroll traces after DOM swap", async () => {
+    const events: Array<string> = [];
+    const records = await Effect.runPromise(
+      unsafeEraseR(
+        traceEventsFor(
+          Effect.gen(function* () {
+            const activation = yield* makeRouteActivation({ emitTraceEvents: true });
+            yield* activation.activate(request("nav-1", "/docs"));
+            yield* activation.commitAfterDomSwap(
+              { activationId: "nav-1", path: "/docs" },
+              Effect.sync(() => events.push("swap")),
+              Effect.sync(() => events.push("scroll")),
+            );
+          }),
+        ),
+      ),
+    );
+
+    expect(events).toEqual(["swap", "scroll"]);
+    expect(eventNames(records)).toEqual([
+      "outlet.process.start",
+      "scroll.apply",
+      "outlet.process.commit",
+    ]);
   });
 
   it("integrates with the canonical matcher for matched routes", async () => {

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -620,11 +620,6 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
           Effect.provide(strategyLayer ?? ScrollStrategy.Auto),
         );
         yield* router.outletCoordination.applyScroll({ strategy });
-        yield* ContractTrace.emit({
-          event: "scroll.apply",
-          level: "semantic",
-          payload: { kind: strategy._tag },
-        });
       }).pipe(
         Effect.catchCause((cause) =>
           ContractTrace.emit({
@@ -722,11 +717,6 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
 
             yield* Effect.forkScoped(
               Effect.gen(function* () {
-                yield* ContractTrace.emit({
-                  event: "outlet.lazyLeaf.load.start",
-                  level: "semantic",
-                  payload: { path: routeIdentity.path },
-                });
                 const component = yield* routeActivationBoundary.loadComponent(options.request, loader);
                 const leafElement = yield* renderComponent(
                   component,
@@ -734,28 +724,16 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
                   decodedQuery,
                   routeIdentity,
                 );
-                yield* ContractTrace.emit({
-                  event: "outlet.lazyLeaf.load.ready",
-                  level: "semantic",
-                  payload: { path: routeIdentity.path },
-                });
                 yield* Signal.set(childSignal, leafElement);
               }).pipe(
                 Effect.catchCause((cause) =>
-                  Effect.gen(function* () {
-                    yield* ContractTrace.emit({
-                      event: "outlet.lazyLeaf.load.error",
-                      level: "semantic",
-                      payload: { path: routeIdentity.path, cause: Cause.pretty(cause) },
-                    });
-                    yield* Signal.set(
-                      childSignal,
-                      Element.fail(Cause.squash(cause), {
-                        identity: outletLazyLeafIdentity,
-                        inputs: { routeIdentity, phase: "error" },
-                      }),
-                    );
-                  }),
+                  Signal.set(
+                    childSignal,
+                    Element.fail(Cause.squash(cause), {
+                      identity: outletLazyLeafIdentity,
+                      inputs: { routeIdentity, phase: "error" },
+                    }),
+                  ),
                 ),
               ),
             );
@@ -907,32 +885,14 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
               setViewAndAwaitSwap(currentView),
               applyScroll(strategyLayer),
             );
-            yield* ContractTrace.emit({
-              event: "outlet.process.commit",
-              level: "semantic",
-              payload: {
-                path: routePath,
-                routePattern: match.route.path,
-                query: queryString,
-                epoch,
-              },
-            });
+            void epoch;
           } else {
             yield* routeActivation.showLoadingFallback(
               { activationId, path: routePath },
               Signal.set(viewSignal, currentView),
             );
-            yield* ContractTrace.emit({
-              event: "outlet.process.commit",
-              level: "semantic",
-              payload: {
-                path: routePath,
-                routePattern: match.route.path,
-                query: queryString,
-                epoch,
-                state: currentState._tag,
-              },
-            });
+            void currentState;
+            void epoch;
           }
         } else {
           const rendered = yield* renderEffect;
@@ -941,11 +901,8 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
             setViewAndAwaitSwap(rendered),
             applyScroll(resolveScrollStrategy(match.route)),
           );
-          yield* ContractTrace.emit({
-            event: "outlet.process.commit",
-            level: "semantic",
-            payload: { path: routePath, routePattern: match.route.path, query: queryString, epoch },
-          });
+          void queryString;
+          void epoch;
         }
       });
 
@@ -960,11 +917,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       const activationId = nextActivationId();
       const epoch = routeEpoch;
       const route = yield* SubscriptionRef.get(router.current._ref);
-      yield* ContractTrace.emit({
-        event: "outlet.process.start",
-        level: "semantic",
-        payload: { path: route.path, epoch, activationId },
-      });
+      void epoch;
       const activationRequest: RouteActivationRequest = {
         activationId,
         path: route.path,
@@ -977,11 +930,6 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
 
       // 404
       if (Option.isNone(matchOption)) {
-        yield* ContractTrace.emit({
-          event: "outlet.match.notFound",
-          level: "semantic",
-          payload: { path: route.path, epoch },
-        });
         const notFoundIntent = yield* routeActivationBoundary.resolveNotFoundBoundary(
           activationRequest,
         );
@@ -1000,12 +948,6 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       }
 
       const match = matchOption.value;
-      yield* ContractTrace.emit({
-        event: "outlet.match.found",
-        level: "semantic",
-        payload: { path: route.path, routePattern: match.route.path, epoch },
-      });
-
       // Middleware
       const middlewareIntent = yield* routeActivationBoundary.resolveMiddleware(
         activationRequest,

--- a/packages/core/src/router/route-activation.ts
+++ b/packages/core/src/router/route-activation.ts
@@ -12,6 +12,7 @@
  */
 import { Data, Deferred, Effect, Layer, Option, Schema, Scope, SynchronizedRef } from "effect";
 import * as Context from "effect/Context";
+import * as ContractTrace from "../contract/trace.js";
 import type { ScrollIntent } from "./navigation-outlet-coordination.js";
 import type { RouteMatch, RouteMatcherShape } from "./matching.js";
 import type { MiddlewareResult } from "./route.js";
@@ -41,6 +42,35 @@ export const RouteActivationConfigInput = Schema.Struct({
 });
 
 type RouteActivationConfig = typeof RouteActivationConfigInput.Type;
+
+const activationPayload = (request: Pick<RouteActivationRequest, "activationId" | "path">) => ({
+  activationId: request.activationId,
+  path: request.path,
+});
+
+const emitActivationTrace = (
+  enabled: boolean,
+  event: ContractTrace.ContractTraceEventName,
+  payload: Record<string, unknown>,
+): Effect.Effect<void> =>
+  enabled
+    ? ContractTrace.emit({ event, level: "semantic", payload }).pipe(Effect.ignore)
+    : Effect.void;
+
+const emitBoundaryTrace = (
+  event: ContractTrace.ContractTraceEventName,
+  payload: Record<string, unknown>,
+): Effect.Effect<void> => ContractTrace.emit({ event, level: "semantic", payload }).pipe(Effect.ignore);
+
+const boundaryOutcomePayload = (
+  request: Pick<RouteActivationRequest, "activationId" | "path">,
+  outcome: RouteActivationRenderIntent | { readonly _tag: "Continue" },
+  phase: string,
+): Record<string, unknown> => ({
+  ...activationPayload(request),
+  phase,
+  outcome: outcome._tag,
+});
 
 export interface RouteActivationShape {
   readonly activate: (
@@ -74,13 +104,24 @@ export const makeRouteActivation = (
       Effect.gen(function* () {
         const latest = yield* SynchronizedRef.get(current);
         if (Option.isSome(latest) && latest.value !== activationId) {
-          return { _tag: "DroppedStale", activationId, supersededBy: latest.value } as const;
+          const outcome = { _tag: "DroppedStale", activationId, supersededBy: latest.value } as const;
+          yield* emitActivationTrace(config.emitTraceEvents, "outlet.process.dropStale", {
+            activationId,
+            path,
+            supersededBy: latest.value,
+          });
+          return outcome;
         }
         return { _tag: "Committed", activationId, path } as const;
       });
 
     return {
       activate: Effect.fn("RouteActivation.activate")(function* (request) {
+        yield* emitActivationTrace(config.emitTraceEvents, "outlet.process.start", {
+          ...activationPayload(request),
+          query: request.query.toString(),
+          hasScrollIntent: Option.isSome(request.scrollIntent),
+        });
         yield* SynchronizedRef.set(current, Option.some(request.activationId));
         if (matcher !== undefined) {
           const match = yield* matcher.match(request.path).pipe(
@@ -94,14 +135,26 @@ export const makeRouteActivation = (
             ),
           );
           if (Option.isNone(match)) {
+            yield* emitActivationTrace(config.emitTraceEvents, "outlet.match.notFound", {
+              ...activationPayload(request),
+            });
             return { _tag: "NotFound", activationId: request.activationId, path: request.path };
           }
+          yield* emitActivationTrace(config.emitTraceEvents, "outlet.match.found", {
+            ...activationPayload(request),
+            routePattern: match.value.route.path,
+          });
         }
-        void config;
         return { _tag: "Committed", activationId: request.activationId, path: request.path };
       }),
       commit: Effect.fn("RouteActivation.commit")(function* (request) {
-        return yield* currentOrStale(request.activationId, request.path);
+        const outcome = yield* currentOrStale(request.activationId, request.path);
+        if (outcome._tag === "Committed") {
+          yield* emitActivationTrace(config.emitTraceEvents, "outlet.process.commit", {
+            ...activationPayload(request),
+          });
+        }
+        return outcome;
       }),
       currentActivationId: SynchronizedRef.get(current),
       waitForDomSwap: Effect.fn("RouteActivation.waitForDomSwap")(function* (_activationId) {
@@ -114,6 +167,10 @@ export const makeRouteActivation = (
         const outcome = yield* currentOrStale(request.activationId, request.path);
         if (outcome._tag === "DroppedStale") return outcome;
         yield* show;
+        yield* emitActivationTrace(config.emitTraceEvents, "outlet.process.commit", {
+          ...activationPayload(request),
+          state: "Loading",
+        });
         return outcome;
       }),
       commitAfterDomSwap: Effect.fn("RouteActivation.commitAfterDomSwap")(function* (
@@ -127,6 +184,12 @@ export const makeRouteActivation = (
         const afterDomSwap = yield* currentOrStale(request.activationId, request.path);
         if (afterDomSwap._tag === "DroppedStale") return afterDomSwap;
         yield* afterSwap;
+        yield* emitActivationTrace(config.emitTraceEvents, "scroll.apply", {
+          ...activationPayload(request),
+        });
+        yield* emitActivationTrace(config.emitTraceEvents, "outlet.process.commit", {
+          ...activationPayload(request),
+        });
         return afterDomSwap;
       }),
     };
@@ -238,7 +301,14 @@ export const makeRouteActivationBoundary = (
       request: RouteActivationRequest,
       component: ComponentInput,
     ) {
+      yield* emitBoundaryTrace("outlet.lazyLeaf.load.start", activationPayload(request));
       const loaded = yield* dependencies.loadComponent(component).pipe(
+        Effect.tapError((cause) =>
+          emitBoundaryTrace("outlet.lazyLeaf.load.error", {
+            ...activationPayload(request),
+            cause: String(cause),
+          }),
+        ),
         Effect.mapError(
           (cause) =>
             new LazyRouteLoadError({ activationId: request.activationId, path: request.path, cause }),
@@ -246,12 +316,17 @@ export const makeRouteActivationBoundary = (
       );
       const stale = yield* dependencies.isStale(request.activationId);
       if (config.interruptStaleLoads && stale) {
+        yield* emitBoundaryTrace("outlet.lazyLeaf.load.error", {
+          ...activationPayload(request),
+          cause: "stale activation",
+        });
         return yield* new LazyRouteLoadError({
           activationId: request.activationId,
           path: request.path,
           cause: "stale activation",
         });
       }
+      yield* emitBoundaryTrace("outlet.lazyLeaf.load.ready", activationPayload(request));
       return loaded;
     });
 
@@ -267,12 +342,27 @@ export const makeRouteActivationBoundary = (
           component !== undefined &&
           dependencies.isComponentLoader(component)
         ) {
-          return { _tag: "Loading", component: loading.value };
+          const outcome = { _tag: "Loading", component: loading.value } as const;
+          yield* emitBoundaryTrace(
+            "outlet.boundary.resolve",
+            boundaryOutcomePayload(request, outcome, "render"),
+          );
+          return outcome;
         }
         if (component !== undefined) {
-          return { _tag: "Leaf", component };
+          const outcome = { _tag: "Leaf", component } as const;
+          yield* emitBoundaryTrace(
+            "outlet.boundary.resolve",
+            boundaryOutcomePayload(request, outcome, "render"),
+          );
+          return outcome;
         }
-        return { _tag: "NoBoundary", cause: "route has no component" };
+        const outcome = { _tag: "NoBoundary", cause: "route has no component" } as const;
+        yield* emitBoundaryTrace(
+          "outlet.boundary.resolve",
+          boundaryOutcomePayload(request, outcome, "render"),
+        );
+        return outcome;
       }),
       prefetch: Effect.fn("RouteActivationBoundary.prefetch")(function* (path) {
         const parsed = yield* parsePath(path).pipe(Effect.orDie);
@@ -295,26 +385,41 @@ export const makeRouteActivationBoundary = (
       ) {
         if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
         const component = dependencies.resolveError(match, cause);
-        return Option.isSome(component)
-          ? { _tag: "ErrorBoundary", component: component.value, cause }
+        const outcome = Option.isSome(component)
+          ? ({ _tag: "ErrorBoundary", component: component.value, cause } as const)
           : noBoundary(request, "missing error boundary", cause);
+        yield* emitBoundaryTrace(
+          "outlet.boundary.resolve",
+          boundaryOutcomePayload(request, outcome, "error"),
+        );
+        return outcome;
       }),
       resolveNotFoundBoundary: Effect.fn("RouteActivationBoundary.resolveNotFoundBoundary")(
         function* (request) {
           if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
           const component = dependencies.resolveNotFound(request.path);
-          return Option.isSome(component)
-            ? { _tag: "NotFoundBoundary", component: component.value }
+          const outcome = Option.isSome(component)
+            ? ({ _tag: "NotFoundBoundary", component: component.value } as const)
             : noBoundary(request, "missing not-found boundary", "not found");
+          yield* emitBoundaryTrace(
+            "outlet.boundary.resolve",
+            boundaryOutcomePayload(request, outcome, "notFound"),
+          );
+          return outcome;
         },
       ),
       resolveForbiddenBoundary: Effect.fn("RouteActivationBoundary.resolveForbiddenBoundary")(
         function* (request, match) {
           if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
           const component = dependencies.resolveForbidden(match);
-          return Option.isSome(component)
-            ? { _tag: "ForbiddenBoundary", component: component.value }
+          const outcome = Option.isSome(component)
+            ? ({ _tag: "ForbiddenBoundary", component: component.value } as const)
             : noBoundary(request, "missing forbidden boundary", "forbidden");
+          yield* emitBoundaryTrace(
+            "outlet.boundary.resolve",
+            boundaryOutcomePayload(request, outcome, "forbidden"),
+          );
+          return outcome;
         },
       ),
       resolveMiddleware: Effect.fn("RouteActivationBoundary.resolveMiddleware")(function* (
@@ -323,24 +428,34 @@ export const makeRouteActivationBoundary = (
       ) {
         if (yield* dependencies.isStale(request.activationId)) return yield* staleBoundaryError(request);
         const result = yield* dependencies.runMiddleware(match);
+        let outcome: RouteActivationRenderIntent | { readonly _tag: "Continue" };
         switch (result._tag) {
           case "Continue":
-            return { _tag: "Continue" } as const;
+            outcome = { _tag: "Continue" } as const;
+            break;
           case "Redirect":
-            return { _tag: "Redirect", location: result.path, replace: result.replace } as const;
+            outcome = { _tag: "Redirect", location: result.path, replace: result.replace } as const;
+            break;
           case "Forbidden": {
             const component = dependencies.resolveForbidden(match);
-            return Option.isSome(component)
-              ? { _tag: "ForbiddenBoundary", component: component.value }
+            outcome = Option.isSome(component)
+              ? ({ _tag: "ForbiddenBoundary", component: component.value } as const)
               : noBoundary(request, "missing forbidden boundary", "forbidden");
+            break;
           }
           case "Error": {
             const component = dependencies.resolveError(match, result.cause);
-            return Option.isSome(component)
-              ? { _tag: "ErrorBoundary", component: component.value, cause: result.cause }
+            outcome = Option.isSome(component)
+              ? ({ _tag: "ErrorBoundary", component: component.value, cause: result.cause } as const)
               : noBoundary(request, "missing error boundary", result.cause);
+            break;
           }
         }
+        yield* emitBoundaryTrace(
+          "outlet.boundary.resolve",
+          boundaryOutcomePayload(request, outcome, "middleware"),
+        );
+        return outcome;
       }),
     };
   });


### PR DESCRIPTION
## Summary

Moves route activation trace ownership into `RouteActivation` / `RouteActivationBoundary` and adds semantic assertions for activation start, match/not-found, stale drops, lazy load outcomes, boundary outcomes, route commit, and scroll-after-swap ordering.

## DX impact

Before, Outlet emitted activation-flavored traces from rendering glue, so behavior contracts had to trust helper timing:

```ts
yield* ContractTrace.emit({ event: "outlet.process.commit", payload: { path } })
```

After, contracts assert the RouteActivation ownership seam directly:

```ts
expect(eventNames(records)).toEqual([
  "outlet.process.start",
  "outlet.match.found",
  "scroll.apply",
  "outlet.process.commit",
])
```

## Acceptance criteria

- [x] RouteActivation emits semantic trace events at documented start/match/drop/commit/scroll seams.
- [x] RouteActivationBoundary emits semantic trace events for lazy load and boundary outcomes.
- [x] Behavior-contract tests cover latest-route-wins/stale drop and lazy/boundary activation traces.
- [x] Trace payloads use stable activation ids and route domain terms.
- [x] App-facing route behavior remains unchanged outside verifier-facing traces.

## Weird spots / attention needed

- `outlet.boundary.resolve` is a new verifier-facing event name so boundary outcomes can be asserted without overloading match or commit events.
- Outlet no longer emits duplicate activation/lazy/scroll events; those records now come from the RouteActivation seams while Outlet still performs rendering and DOM work.
- `scroll.apply` is emitted after the supplied after-swap effect returns, so contracts can assert that scroll is sequenced after the visible DOM replacement.

## Validation

- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/router/__tests__/route-activation.test.ts src/router/__tests__/outlet-navigation.test.tsx src/router/__tests__/outlet-rendering.test.ts`
- `bun run --cwd packages/core docs:check`
- `bun run --cwd packages/core test`

Closes #242.
Refs #217.
Refs #218.
Refs #223.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. **#261** 👈 current
26. #262
<!-- stack:links:end -->