### PR TITLE
feat(core): trace render transaction semantics

### DIFF
--- a/packages/core/src/contract/trace.docs.md
+++ b/packages/core/src/contract/trace.docs.md
@@ -32,6 +32,7 @@ Stable payload fields:
 - `replace`: boolean replacement intent for push/replace requests.
 - `previous` / `next`: committed **Current route** snapshots with `path`, `query`, `hash`, `scrollKey`, and `isPopstate`.
 - `previousQuery` / `nextQuery`: canonical query strings for query changes.
+- `changed`: whether a query notification represents a canonical query value change.
 
 Ordering guarantees:
 
@@ -77,6 +78,7 @@ Events:
 - `signalElement.swap.start`
 - `signalElement.swap.render`
 - `signalElement.swap.dropStale`
+- `signalElement.swap.failBeforeCommit`
 - `signalElement.swap.commit`
 - `signalElement.cleanup`
 - `dom.create`
@@ -88,8 +90,9 @@ Ordering guarantees:
 1. A no-blank replacement renders the next **Element** before removing the previous visible DOM.
 2. `signalElement.swap.render` precedes `signalElement.swap.commit` for successful SignalElement swaps.
 3. `signalElement.swap.dropStale` means the rendered result was superseded and must be cleaned without becoming visible.
-4. `signalElement.cleanup` and `dom.remove` describe cleanup after a safe commit or unmount, not pre-commit blanking.
-5. `component.render` is a cost/semantic boundary for the **Component** producing an **Element** tree; it must not imply a provider scope replacement by itself.
+4. `signalElement.swap.failBeforeCommit` means rendering or reconciliation failed before previous visible DOM was removed.
+5. `signalElement.cleanup` and `dom.remove` describe cleanup after a safe commit or unmount, not pre-commit blanking.
+6. `component.render` is a cost/semantic boundary for the **Component** producing an **Element** tree; it must not imply a provider scope replacement by itself.
 
 ### Provider and signal lifecycle family
 
@@ -120,6 +123,15 @@ Ordering guarantees:
 Events:
 
 - `scroll.apply`
+
+Stable payload fields:
+
+- `kind`: `hash`, `restore`, `top`, `none`, or `ignoredError`.
+- `strategy`: selected scroll strategy tag.
+- `hash`: committed navigation hash used for hash-scroll decisions.
+- `isPopstate`: whether the activation came from browser history traversal.
+- `scrollKey`: storage key used for restore decisions.
+- `restored`: present on restore decisions to indicate whether a saved position was available.
 
 Ordering guarantees:
 

--- a/packages/core/src/contract/trace.ts
+++ b/packages/core/src/contract/trace.ts
@@ -67,6 +67,7 @@ export type ContractTraceEventName =
   | "signalElement.swap.start"
   | "signalElement.swap.render"
   | "signalElement.swap.dropStale"
+  | "signalElement.swap.failBeforeCommit"
   | "signalElement.swap.commit"
   | "signalElement.cleanup"
   | "scroll.apply"

--- a/packages/core/src/primitives/__tests__/render-context-transaction.test.ts
+++ b/packages/core/src/primitives/__tests__/render-context-transaction.test.ts
@@ -5,9 +5,23 @@ import {
   type RenderContextSnapshot,
 } from "../render-context-transaction.js";
 import * as SafeUrl from "../../security/safe-url.js";
+import * as ContractTrace from "../../contract/trace.js";
 import { unsafeWidenContext } from "../../internal/unsafe.js";
 
 class Message extends Context.Service<Message, { readonly value: string }>()("test/Message") {}
+
+const traceEventsFor = <E, R>(
+  effect: Effect.Effect<void, E, R>,
+): Effect.Effect<ReadonlyArray<ContractTrace.ContractTraceRecord>, E, R> =>
+  Effect.gen(function* () {
+    const collector = yield* ContractTrace.createInMemoryCollector("render-context-transaction");
+    yield* ContractTrace.withCollector(effect, collector);
+    return yield* collector.snapshot;
+  });
+
+const eventNames = (
+  records: ReadonlyArray<ContractTrace.ContractTraceRecord>,
+): ReadonlyArray<ContractTrace.ContractTraceEventName> => records.map((record) => record.event.event);
 
 const makeSnapshot = async (): Promise<RenderContextSnapshot> => {
   const scope = await Effect.runPromise(Scope.make());
@@ -32,6 +46,51 @@ describe("RenderContextTransaction", () => {
     );
 
     expect(value).toBe("root");
+  });
+
+  it("emits scoped fork and scope close lifecycle traces", async () => {
+    const transaction = makeRenderContextTransaction({ emitLifecycleTraceEvents: true });
+    const parent = await makeSnapshot();
+
+    const records = await Effect.runPromise(
+      traceEventsFor(
+        Effect.gen(function* () {
+          const child = yield* transaction.forkContext({
+            parent,
+            additionalServices: Option.none(),
+            scopeOwner: "component",
+          });
+          yield* transaction.finalizeOwnedScope(child);
+        }),
+      ),
+    );
+
+    expect(eventNames(records)).toEqual(["effect.fork.scoped", "effect.scope.close"]);
+    expect(records[0]?.event.payload).toMatchObject({ owner: "component" });
+  });
+
+  it("finalizes provider, signal, portal, and boundary owned scopes", async () => {
+    const transaction = makeRenderContextTransaction({ emitLifecycleTraceEvents: true });
+    const parent = await makeSnapshot();
+    const finalized: Array<string> = [];
+
+    for (const scopeOwner of ["provider", "signal", "portal", "boundary"] as const) {
+      const child = await Effect.runPromise(
+        transaction.forkContext({
+          parent,
+          additionalServices: Option.none(),
+          scopeOwner,
+        }),
+      );
+      await Effect.runPromise(
+        Effect.addFinalizer(() => Effect.sync(() => finalized.push(scopeOwner))).pipe(
+          Scope.provide(child.scope),
+        ),
+      );
+      await Effect.runPromise(transaction.finalizeOwnedScope(child));
+    }
+
+    expect(finalized).toEqual(["provider", "signal", "portal", "boundary"]);
   });
 
   it("forks and finalizes owned render scopes with additional services", async () => {

--- a/packages/core/src/primitives/__tests__/render-transaction.test.ts
+++ b/packages/core/src/primitives/__tests__/render-transaction.test.ts
@@ -1,15 +1,34 @@
 import { describe, expect, it } from "vitest";
 import { Context, Effect, Option, Scope } from "effect";
+import * as ContractTrace from "../../contract/trace.js";
+import { unsafeWidenContext } from "../../internal/unsafe.js";
 import { makeRenderTransaction } from "../render-transaction.js";
 import * as SafeUrl from "../../security/safe-url.js";
 import { Element } from "../element.js";
 import type { RenderContext, RenderResult } from "../renderer.js";
 
-const context: RenderContext = {
-  services: Context.empty() as Context.Context<unknown>,
-  scope: {} as Scope.Scope,
-  safeUrlConfig: SafeUrl.defaultConfig,
-};
+const makeContext = (): Effect.Effect<RenderContext> =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+    return {
+      services: unsafeWidenContext(Context.empty()),
+      scope,
+      safeUrlConfig: SafeUrl.defaultConfig,
+    };
+  });
+
+const traceEventsFor = <E, R>(
+  effect: Effect.Effect<void, E, R>,
+): Effect.Effect<ReadonlyArray<ContractTrace.ContractTraceRecord>, E, R> =>
+  Effect.gen(function* () {
+    const collector = yield* ContractTrace.createInMemoryCollector("render-transaction");
+    yield* ContractTrace.withCollector(effect, collector);
+    return yield* collector.snapshot;
+  });
+
+const eventNames = (
+  records: ReadonlyArray<ContractTrace.ContractTraceRecord>,
+): ReadonlyArray<ContractTrace.ContractTraceEventName> => records.map((record) => record.event.event);
 
 const result = (node: Node, cleanupLog: Array<string>, label: string): RenderResult => ({
   node,
@@ -28,6 +47,7 @@ describe("RenderTransaction", () => {
     const cleanupSnapshots: Array<string> = [];
     const transaction = makeRenderTransaction({ emitTraceEvents: false });
     const previous = result(previousNode, cleanupSnapshots, "old");
+    const context = await Effect.runPromise(makeContext());
 
     const outcome = await Effect.runPromise(
       transaction.replace({
@@ -50,6 +70,7 @@ describe("RenderTransaction", () => {
   it("represents reconcile success and skipped fallback explicitly", async () => {
     const node = document.createElement("div");
     const transaction = makeRenderTransaction({ emitTraceEvents: false });
+    const context = await Effect.runPromise(makeContext());
     const previous = {
       ...result(node, [], "previous"),
       reconcile: () => Effect.succeed(true),
@@ -76,12 +97,75 @@ describe("RenderTransaction", () => {
     expect(skipped._tag).toBe("NotReconciled");
   });
 
+  it("emits no-blank replacement and cleanup traces", async () => {
+    const parent = document.createElement("div");
+    const previousNode = document.createElement("span");
+    previousNode.textContent = "old";
+    parent.appendChild(previousNode);
+    const transaction = makeRenderTransaction({ emitTraceEvents: true });
+    const context = await Effect.runPromise(makeContext());
+
+    const records = await Effect.runPromise(
+      traceEventsFor(
+        transaction
+          .replace({
+            parent,
+            previous: Option.some(result(previousNode, [], "old")),
+            renderNext: Effect.sync(() => {
+              const nextNode = document.createElement("strong");
+              nextNode.textContent = "new";
+              return result(nextNode, [], "new");
+            }),
+            context,
+          })
+          .pipe(Effect.asVoid, Effect.scoped),
+      ),
+    );
+
+    expect(eventNames(records)).toEqual([
+      "signalElement.swap.start",
+      "signalElement.swap.render",
+      "signalElement.swap.commit",
+      "signalElement.cleanup",
+    ]);
+    expect(parent.textContent).toBe("new");
+  });
+
+  it("emits failed-before-commit traces without blanking previous UI", async () => {
+    const parent = document.createElement("div");
+    const previousNode = document.createElement("span");
+    previousNode.textContent = "old";
+    parent.appendChild(previousNode);
+    const transaction = makeRenderTransaction({ emitTraceEvents: true });
+    const context = await Effect.runPromise(makeContext());
+
+    const records = await Effect.runPromise(
+      traceEventsFor(
+        transaction
+          .replace({
+            parent,
+            previous: Option.some(result(previousNode, [], "old")),
+            renderNext: Effect.fail("boom"),
+            context,
+          })
+          .pipe(Effect.asVoid, Effect.scoped),
+      ),
+    );
+
+    expect(eventNames(records)).toEqual([
+      "signalElement.swap.start",
+      "signalElement.swap.failBeforeCommit",
+    ]);
+    expect(parent.textContent).toBe("old");
+  });
+
   it("preserves previous UI when render fails before commit", async () => {
     const parent = document.createElement("div");
     const previousNode = document.createElement("span");
     previousNode.textContent = "old";
     parent.appendChild(previousNode);
     const transaction = makeRenderTransaction({ emitTraceEvents: false });
+    const context = await Effect.runPromise(makeContext());
 
     const outcome = await Effect.runPromise(
       transaction.replace({

--- a/packages/core/src/primitives/render-context-transaction.ts
+++ b/packages/core/src/primitives/render-context-transaction.ts
@@ -1,5 +1,6 @@
 import { Data, Effect, Exit, Layer, Option, Schema, Scope } from "effect";
 import * as Context from "effect/Context";
+import * as ContractTrace from "../contract/trace.js";
 import type { RenderContext } from "./renderer.js";
 
 export type RenderContextSnapshot = RenderContext;
@@ -21,6 +22,15 @@ export const RenderContextTransactionConfigInput = Schema.Struct({
 
 type RenderContextTransactionConfig = typeof RenderContextTransactionConfigInput.Type;
 
+const emitLifecycleTrace = (
+  enabled: boolean,
+  event: ContractTrace.ContractTraceEventName,
+  payload: Record<string, unknown>,
+): Effect.Effect<void> =>
+  enabled
+    ? ContractTrace.emit({ event, level: "semantic", payload }).pipe(Effect.ignore)
+    : Effect.void;
+
 export interface RenderContextTransactionShape {
   readonly forkContext: (
     request: RenderContextForkRequest,
@@ -36,10 +46,12 @@ export const makeRenderContextTransaction = (
   configInput: RenderContextTransactionConfig,
 ): RenderContextTransactionShape => {
   const config = RenderContextTransactionConfigInput.make(configInput);
-  void config;
 
   return {
     forkContext: Effect.fn("RenderContextTransaction.forkContext")(function* (request) {
+      yield* emitLifecycleTrace(config.emitLifecycleTraceEvents, "effect.fork.scoped", {
+        owner: request.scopeOwner,
+      });
       const scope = yield* Scope.fork(request.parent.scope).pipe(
         Effect.mapError(
           (cause) => new RenderContextOwnershipError({ owner: request.scopeOwner, cause }),
@@ -61,6 +73,9 @@ export const makeRenderContextTransaction = (
       snapshot,
     ) {
       yield* Scope.close(snapshot.scope, Exit.void).pipe(Effect.orDie);
+      yield* emitLifecycleTrace(config.emitLifecycleTraceEvents, "effect.scope.close", {
+        owner: "render-context",
+      });
     }),
   };
 };

--- a/packages/core/src/primitives/render-intrinsic.ts
+++ b/packages/core/src/primitives/render-intrinsic.ts
@@ -1,4 +1,4 @@
-import { Effect, Option } from "effect";
+import { Effect, Fiber, Option, Scope } from "effect";
 import * as Context from "effect/Context";
 import { Element, getKey, type ElementProps, type EventHandler } from "./element.js";
 import * as Signal from "./signal.js";
@@ -124,8 +124,11 @@ const applyProps = Effect.fn("applyProps")(function* (
 
       const eventName = key.slice(2).toLowerCase();
       const listener = (event: Event) => {
-        Effect.runForkWith(Context.empty())(
+        const fiber = Effect.runForkWith(Context.empty())(
           contextTransaction.runEventHandler(eventSnapshot, value(event)),
+        );
+        void Effect.runPromiseWith(Context.empty())(
+          Scope.addFinalizer(eventSnapshot.scope, Fiber.interrupt(fiber)),
         );
       };
       node.addEventListener(eventName, listener);

--- a/packages/core/src/primitives/render-transaction.ts
+++ b/packages/core/src/primitives/render-transaction.ts
@@ -1,5 +1,6 @@
 import { Cause, Data, Effect, Exit, Layer, Option, Schema } from "effect";
 import * as Context from "effect/Context";
+import * as ContractTrace from "../contract/trace.js";
 import type { Element } from "./element.js";
 import type { RenderContext, RenderResult } from "./renderer.js";
 
@@ -34,6 +35,15 @@ export const RenderTransactionConfigInput = Schema.Struct({
 
 type RenderTransactionConfig = typeof RenderTransactionConfigInput.Type;
 
+const emitRenderTrace = (
+  enabled: boolean,
+  event: ContractTrace.ContractTraceEventName,
+  payload: Record<string, unknown>,
+): Effect.Effect<void> =>
+  enabled
+    ? ContractTrace.emit({ event, level: "semantic", payload }).pipe(Effect.ignore)
+    : Effect.void;
+
 export interface RenderTransactionShape {
   readonly replace: (
     request: RenderTransactionRequest,
@@ -48,17 +58,29 @@ export const makeRenderTransaction = (
   configInput: RenderTransactionConfig,
 ): RenderTransactionShape => {
   const config = RenderTransactionConfigInput.make(configInput);
-  void config;
 
   return {
     replace: Effect.fn("RenderTransaction.replace")(function* (request) {
+      yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.start", {
+        operation: "replace",
+        hasPrevious: Option.isSome(request.previous),
+      });
       const rendered = yield* Effect.exit(
         request.renderNext.pipe(Effect.provide(request.context.services)),
       );
       if (Exit.isFailure(rendered)) {
-        return { _tag: "FailedBeforeCommit", cause: Cause.squash(rendered.cause) };
+        const cause = Cause.squash(rendered.cause);
+        yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.failBeforeCommit", {
+          operation: "replace",
+          phase: "render",
+          cause: String(cause),
+        });
+        return { _tag: "FailedBeforeCommit", cause };
       }
 
+      yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.render", {
+        operation: "replace",
+      });
       const next = rendered.value;
       const previous = Option.getOrUndefined(request.previous);
 
@@ -75,7 +97,15 @@ export const makeRenderTransaction = (
         catch: (cause) => new RenderTransactionError({ phase: "commit", cause }),
       });
 
+      yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.commit", {
+        operation: "replace",
+      });
+
       if (previous !== undefined) {
+        yield* emitRenderTrace(config.emitTraceEvents, "signalElement.cleanup", {
+          operation: "replace",
+          reason: "previous-result",
+        });
         yield* previous.cleanup.pipe(
           Effect.provide(request.context.services),
           Effect.mapError((cause) => new RenderTransactionError({ phase: "cleanup", cause })),
@@ -85,6 +115,9 @@ export const makeRenderTransaction = (
       return { _tag: "Committed", result: next };
     }),
     reconcile: Effect.fn("RenderTransaction.reconcile")(function* (request) {
+      yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.start", {
+        operation: "reconcile",
+      });
       if (request.previous.reconcile === undefined) {
         return { _tag: "NotReconciled", result: request.previous };
       }
@@ -95,14 +128,33 @@ export const makeRenderTransaction = (
           .pipe(Effect.provide(request.context.services)),
       );
       if (Exit.isFailure(reconciled)) {
-        return { _tag: "FailedBeforeCommit", cause: Cause.squash(reconciled.cause) };
+        const cause = Cause.squash(reconciled.cause);
+        yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.failBeforeCommit", {
+          operation: "reconcile",
+          phase: "render",
+          cause: String(cause),
+        });
+        return { _tag: "FailedBeforeCommit", cause };
       }
 
+      yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.render", {
+        operation: "reconcile",
+        reconciled: reconciled.value,
+      });
+      if (reconciled.value) {
+        yield* emitRenderTrace(config.emitTraceEvents, "signalElement.swap.commit", {
+          operation: "reconcile",
+        });
+      }
       return reconciled.value
         ? { _tag: "Reconciled", result: request.previous }
         : { _tag: "NotReconciled", result: request.previous };
     }),
     cleanup: Effect.fn("RenderTransaction.cleanup")(function* (result) {
+      yield* emitRenderTrace(config.emitTraceEvents, "signalElement.cleanup", {
+        operation: "cleanup",
+        reason: "explicit",
+      });
       yield* result.cleanup.pipe(Effect.provide(Context.empty() as Context.Context<unknown>));
     }),
   };

--- a/packages/core/src/router/__tests__/navigation-core.test.ts
+++ b/packages/core/src/router/__tests__/navigation-core.test.ts
@@ -206,20 +206,40 @@ describe("NavigationCore semantic traces", () => {
     }),
   );
 
-  it.effect("suppresses unchanged query trace events", () =>
+  it.effect("suppresses unchanged query trace events unless explicitly configured", () =>
     Effect.gen(function* () {
-      const records = yield* traceEventsFor(
+      const suppressed = yield* traceEventsFor(
         Effect.gen(function* () {
           const core = yield* makeCore("/dashboard?tab=main");
           yield* core.navigate(navigationTarget("/dashboard", { query: { tab: "main" } }));
         }),
       );
 
-      assert.deepStrictEqual(eventNames(records), [
+      assert.deepStrictEqual(eventNames(suppressed), [
         "router.navigate.request",
         "history.push",
         "router.navigate.commit",
       ]);
+
+      const emitted = yield* traceEventsFor(
+        Effect.gen(function* () {
+          const adapter = yield* makeInMemoryNavigationAdapter("/dashboard?tab=main").pipe(
+            Effect.orDie,
+          );
+          const core = yield* makeNavigationCore({ notifyUnchangedQuery: true }, adapter).pipe(
+            Effect.orDie,
+          );
+          yield* core.navigate(navigationTarget("/dashboard", { query: { tab: "main" } }));
+        }),
+      );
+
+      assert.deepStrictEqual(eventNames(emitted), [
+        "router.navigate.request",
+        "history.push",
+        "router.query.set",
+        "router.navigate.commit",
+      ]);
+      assert.strictEqual(emitted[2]?.event.payload?.changed, false);
     }),
   );
 

--- a/packages/core/src/router/__tests__/route-activation.test.ts
+++ b/packages/core/src/router/__tests__/route-activation.test.ts
@@ -3,6 +3,7 @@ import { Effect, Option, Ref } from "effect";
 import * as ContractTrace from "../../contract/trace.js";
 import { unsafeEraseR } from "../../internal/unsafe.js";
 import type { RouteMatch, RouteMatcherShape } from "../matching.js";
+import type { RouteDefinition } from "../route.js";
 import { makeRouteActivation, makeRouteActivationBoundary } from "../route-activation.js";
 import type { ComponentInput, RouteComponent } from "../types.js";
 
@@ -13,18 +14,39 @@ const request = (activationId: string, path: string) => ({
   scrollIntent: Option.none(),
 });
 
+const makeDefinition = (
+  path: string,
+  overrides: Partial<RouteDefinition> = {},
+): RouteDefinition => ({
+  _tag: "RouteDefinition",
+  path,
+  component: undefined,
+  layout: undefined,
+  loading: undefined,
+  error: undefined,
+  notFound: undefined,
+  forbidden: undefined,
+  middleware: [],
+  prefetch: [],
+  children: [],
+  paramsSchema: undefined,
+  querySchema: undefined,
+  renderStrategy: undefined,
+  scrollStrategy: undefined,
+  ...overrides,
+});
+
 const makeMatch = (
   path: string,
-  definition: Record<string, unknown> = {},
-): RouteMatch =>
-  ({
-    route: {
-      path,
-      ancestors: [],
-      definition: { prefetch: [], ...definition },
-    },
-    params: {},
-  }) as unknown as RouteMatch;
+  definition: Partial<RouteDefinition> = {},
+): RouteMatch => ({
+  route: {
+    path,
+    ancestors: [],
+    definition: makeDefinition(path, definition),
+  },
+  params: {},
+});
 
 const makeMatcher = (matchPath: string, match: RouteMatch = makeMatch(matchPath)): RouteMatcherShape => ({
   routes: Effect.succeed([]),
@@ -75,7 +97,7 @@ describe("RouteActivation", () => {
       ),
     );
 
-    expect(outcome).toEqual({ _tag: "Committed", activationId: "nav-1", path: "/docs" });
+    expect(outcome).toMatchObject({ _tag: "Committed", activationId: "nav-1", path: "/docs" });
   });
 
   it("drops stale activations when a newer activation wins", async () => {
@@ -537,7 +559,10 @@ describe("RouteActivation", () => {
             yield* activation.commitAfterDomSwap(
               { activationId: "nav-1", path: "/docs" },
               Effect.sync(() => events.push("swap")),
-              Effect.sync(() => events.push("scroll")),
+              Effect.sync(() => {
+                events.push("scroll");
+                return { kind: "Auto" };
+              }),
             );
           }),
         ),
@@ -550,6 +575,7 @@ describe("RouteActivation", () => {
       "scroll.apply",
       "outlet.process.commit",
     ]);
+    expect(records[1]?.event.payload).toMatchObject({ kind: "Auto" });
   });
 
   it("integrates with the canonical matcher for matched routes", async () => {
@@ -565,6 +591,6 @@ describe("RouteActivation", () => {
       ),
     );
 
-    expect(outcome).toEqual({ _tag: "Committed", activationId: "nav-1", path: "/known" });
+    expect(outcome).toMatchObject({ _tag: "Committed", activationId: "nav-1", path: "/known" });
   });
 });

--- a/packages/core/src/router/navigation-core.ts
+++ b/packages/core/src/router/navigation-core.ts
@@ -87,6 +87,7 @@ const emitSnapshotChanges = (
   operation: NavigationOperation,
   previous: NavigationSnapshot,
   next: NavigationSnapshot,
+  notifyUnchangedQuery: boolean,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     if (previous.path !== next.path || previous.hash !== next.hash) {
@@ -97,11 +98,13 @@ const emitSnapshotChanges = (
       });
     }
 
-    if (!sameQuery(previous.query, next.query)) {
+    const queryChanged = !sameQuery(previous.query, next.query);
+    if (queryChanged || notifyUnchangedQuery) {
       yield* emitNavigationTrace("router.query.set", {
         operation,
         previousQuery: queryString(previous.query),
         nextQuery: queryString(next.query),
+        changed: queryChanged,
       });
     }
   });
@@ -166,7 +169,7 @@ export const makeNavigationCore = (
         const previous = yield* SynchronizedRef.get(state);
         yield* refresh;
         const next = yield* SynchronizedRef.get(state);
-        yield* emitSnapshotChanges(operation, previous, next);
+        yield* emitSnapshotChanges(operation, previous, next, config.notifyUnchangedQuery);
         yield* emitNavigationTrace("router.navigate.commit", {
           operation,
           previous: snapshotPayload(previous),
@@ -194,7 +197,6 @@ export const makeNavigationCore = (
         }
         yield* emitNavigationTrace(historyEventFor(operation), { operation, url });
         yield* commitSnapshot(operation);
-        void config;
       }),
       back: Effect.gen(function* () {
         yield* emitNavigationTrace("router.navigate.request", { operation: "back" });

--- a/packages/core/src/router/outlet.ts
+++ b/packages/core/src/router/outlet.ts
@@ -619,7 +619,7 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
         const strategy = yield* Effect.service(ScrollStrategy).pipe(
           Effect.provide(strategyLayer ?? ScrollStrategy.Auto),
         );
-        yield* router.outletCoordination.applyScroll({ strategy });
+        return yield* router.outletCoordination.applyScroll({ strategy });
       }).pipe(
         Effect.catchCause((cause) =>
           ContractTrace.emit({
@@ -926,7 +926,11 @@ export const Outlet = Component.gen(function* (Props: ComponentProps<OutletProps
       };
       const activationOutcome = yield* routeActivation.activate(activationRequest);
       const matchOption =
-        activationOutcome._tag === "NotFound" ? Option.none() : yield* matcher.match(route.path);
+        activationOutcome._tag === "Committed" && Option.isSome(activationOutcome.match)
+          ? activationOutcome.match
+          : activationOutcome._tag === "NotFound"
+            ? Option.none()
+            : yield* matcher.match(route.path);
 
       // 404
       if (Option.isNone(matchOption)) {

--- a/packages/core/src/router/route-activation.ts
+++ b/packages/core/src/router/route-activation.ts
@@ -27,7 +27,12 @@ export interface RouteActivationRequest {
 }
 
 export type RouteActivationOutcome =
-  | { readonly _tag: "Committed"; readonly activationId: string; readonly path: string }
+  | {
+      readonly _tag: "Committed";
+      readonly activationId: string;
+      readonly path: string;
+      readonly match: Option.Option<RouteMatch>;
+    }
   | { readonly _tag: "DroppedStale"; readonly activationId: string; readonly supersededBy: string }
   | { readonly _tag: "NotFound"; readonly activationId: string; readonly path: string };
 
@@ -88,7 +93,7 @@ export interface RouteActivationShape {
   readonly commitAfterDomSwap: (
     request: Pick<RouteActivationRequest, "activationId" | "path">,
     swap: Effect.Effect<void>,
-    afterSwap: Effect.Effect<void>,
+    afterSwap: Effect.Effect<unknown>,
   ) => Effect.Effect<RouteActivationOutcome>;
 }
 
@@ -112,7 +117,7 @@ export const makeRouteActivation = (
           });
           return outcome;
         }
-        return { _tag: "Committed", activationId, path } as const;
+        return { _tag: "Committed", activationId, path, match: Option.none<RouteMatch>() } as const;
       });
 
     return {
@@ -144,8 +149,19 @@ export const makeRouteActivation = (
             ...activationPayload(request),
             routePattern: match.value.route.path,
           });
+          return {
+            _tag: "Committed",
+            activationId: request.activationId,
+            path: request.path,
+            match,
+          };
         }
-        return { _tag: "Committed", activationId: request.activationId, path: request.path };
+        return {
+          _tag: "Committed",
+          activationId: request.activationId,
+          path: request.path,
+          match: Option.none<RouteMatch>(),
+        };
       }),
       commit: Effect.fn("RouteActivation.commit")(function* (request) {
         const outcome = yield* currentOrStale(request.activationId, request.path);
@@ -183,9 +199,10 @@ export const makeRouteActivation = (
         yield* swap;
         const afterDomSwap = yield* currentOrStale(request.activationId, request.path);
         if (afterDomSwap._tag === "DroppedStale") return afterDomSwap;
-        yield* afterSwap;
+        const scrollPayload = yield* afterSwap;
         yield* emitActivationTrace(config.emitTraceEvents, "scroll.apply", {
           ...activationPayload(request),
+          ...(typeof scrollPayload === "object" && scrollPayload !== null ? scrollPayload : {}),
         });
         yield* emitActivationTrace(config.emitTraceEvents, "outlet.process.commit", {
           ...activationPayload(request),

--- a/packages/core/src/router/service.ts
+++ b/packages/core/src/router/service.ts
@@ -778,7 +778,13 @@ export const browserLayer: Layer.Layer<
       isPopstate: boolean;
     }) =>
       Effect.gen(function* () {
-        if (opts.strategy._tag === "None") return;
+        const payloadBase = {
+          strategy: opts.strategy._tag,
+          hash: opts.hash,
+          isPopstate: opts.isPopstate,
+          scrollKey: currentNavKey,
+        } as const;
+        if (opts.strategy._tag === "None") return { ...payloadBase, kind: "none" as const };
 
         // Defer until after DOM update — signal element swap runs in a forked
         // fiber (microtask). Without this, scrollTo fires before the new page
@@ -793,7 +799,7 @@ export const browserLayer: Layer.Layer<
           const el = yield* dom.getElementById(id);
           if (el !== null) {
             yield* scroll.scrollIntoView(el);
-            return;
+            return { ...payloadBase, kind: "hash" as const };
           }
         }
 
@@ -809,14 +815,26 @@ export const browserLayer: Layer.Layer<
               y: pos.y,
             });
             yield* scroll.scrollTo(pos.x, pos.y);
+            return { ...payloadBase, kind: "restore" as const, restored: true };
           }
-          return;
+          return { ...payloadBase, kind: "restore" as const, restored: false };
         }
 
         // New navigation: scroll to top
         yield* Debug.log({ event: "router.scroll.top" });
         yield* scroll.scrollTo(0, 0);
-      }).pipe(Effect.ignore);
+        return { ...payloadBase, kind: "top" as const };
+      }).pipe(
+        Effect.catchCause(() =>
+          Effect.succeed({
+            strategy: opts.strategy._tag,
+            hash: opts.hash,
+            isPopstate: opts.isPopstate,
+            scrollKey: currentNavKey,
+            kind: "ignoredError" as const,
+          }),
+        ),
+      );
 
     // Listen to browser popstate (back/forward) via EventTarget service
     // Lifecycle managed by scope — removed when layer scope closes
@@ -982,7 +1000,7 @@ export const browserLayer: Layer.Layer<
             const intent = yield* outletCoordination.takeScrollIntent;
             const navCtx = Option.isSome(intent) ? intent.value : yield* Ref.get(navContextRef);
             yield* Ref.set(navContextRef, navCtx);
-            yield* doApplyScroll({
+            return yield* doApplyScroll({
               strategy: opts.strategy,
               hash: navCtx.hash,
               isPopstate: navCtx.isPopstate,
@@ -1196,7 +1214,16 @@ export const testLayer = (
         outletCoordination: {
           prefetchState: outletCoordination.prefetchState,
           activatePrefetch: outletCoordination.activatePrefetch,
-          applyScroll: () => outletCoordination.takeScrollIntent.pipe(Effect.asVoid),
+          applyScroll: () =>
+            outletCoordination.takeScrollIntent.pipe(
+              Effect.as({
+                kind: "none",
+                strategy: "None",
+                hash: "",
+                isPopstate: false,
+                scrollKey: "test",
+              }),
+            ),
         },
         _saveScroll: Effect.void,
       };

--- a/packages/core/src/router/types.ts
+++ b/packages/core/src/router/types.ts
@@ -602,6 +602,21 @@ export interface RouterService {
 export type OutletPrefetchState = NavigationPrefetchState;
 
 /**
+ * Verifier-facing scroll decision applied after route activation commits DOM.
+ *
+ * @public
+ * @since 1.0.0
+ */
+export interface ScrollApplyPayload {
+  readonly kind: "none" | "hash" | "restore" | "top" | "ignoredError";
+  readonly strategy: ScrollStrategyType["_tag"];
+  readonly hash: string;
+  readonly isPopstate: boolean;
+  readonly scrollKey: string;
+  readonly restored?: boolean;
+}
+
+/**
  * Public coordination seam from Router service to Outlet.
  *
  * @public
@@ -621,5 +636,7 @@ export interface OutletCoordination {
   /**
    * Apply scroll behavior using router-captured platform services.
    */
-  readonly applyScroll: (options: { readonly strategy: ScrollStrategyType }) => Effect.Effect<void>;
+  readonly applyScroll: (options: {
+    readonly strategy: ScrollStrategyType;
+  }) => Effect.Effect<ScrollApplyPayload>;
 }


### PR DESCRIPTION
## Summary

Adds verifier-facing trace emissions to `RenderTransaction` and `RenderContextTransaction` for render swap start/render/commit/failure/cleanup and render-owned scope fork/close seams.

Follow-up review fixes in this PR also close the #212 PRD review gaps that belong at the top of the stack:

- `notifyUnchangedQuery` now drives unchanged query trace notifications and exposes `changed: false`.
- `scroll.apply` now carries hash/restore/top/no-scroll decision payload fields (`kind`, `strategy`, `hash`, `isPopstate`, `scrollKey`, `restored`).
- Route activation returns its resolved match to reduce duplicate Outlet re-resolution after activation.
- Intrinsic event handlers now fork into the render-owned scope instead of using floating `Effect.runForkWith`.
- Render context transaction tests cover provider, signal, Portal, and Boundary scope finalization.
- New test fixtures avoid local type assertions.

## DX impact

Before, transaction tests verified DOM outcomes but could not assert semantic trace ordering:

```ts
const outcome = yield* transaction.replace(request)
expect(parent.textContent).toBe("new")
```

After, behavior contracts can assert no-blank swap and cleanup sequencing directly:

```ts
expect(eventNames(records)).toEqual([
  "signalElement.swap.start",
  "signalElement.swap.render",
  "signalElement.swap.commit",
  "signalElement.cleanup",
])
```

Before, unchanged query notifications and scroll decisions were hard to verify:

```ts
yield* core.navigate(navigationTarget("/dashboard", { query: { tab: "main" } }))
```

After, tests can opt into unchanged query traces and assert scroll decision payloads:

```ts
const core = yield* makeNavigationCore({ notifyUnchangedQuery: true }, adapter)
expect(records[2]?.event.payload?.changed).toBe(false)
expect(scrollRecord.event.payload).toMatchObject({ kind: "top", hash: "", isPopstate: false })
```

## Acceptance criteria

- [x] RenderTransaction emits semantic trace events for replacement start/render/commit/cleanup/failure seams.
- [x] RenderContextTransaction emits or preserves lifecycle trace events for context/scope ownership seams without conflicting with #192.
- [x] Behavior-contract tests assert render transaction cleanup and no-blank swap traces.
- [x] Provider/signal lifecycle trace assertions remain compatible with #187/#192.
- [x] Trace emission remains no-op by default and does not change app-facing render behavior.
- [x] `notifyUnchangedQuery` has observable behavior and tests.
- [x] `scroll.apply` docs and emitted payload fields agree.
- [x] Event handler fibers are scoped to the render context.
- [x] Review-introduced tests avoid local type assertions.

## Weird spots / attention needed

- Adds `signalElement.swap.failBeforeCommit` so failures before visible DOM removal can be asserted without overloading stale-drop semantics.
- Lifecycle tracing stays at Trygg-owned render context boundaries (`effect.fork.scoped`, `effect.scope.close`) rather than attempting to mirror every Effect runtime finalizer.
- Existing provider/signal event names are untouched.
- Scroll failures remain best-effort: failed platform/storage scroll work emits `kind: "ignoredError"` instead of changing activation ordering.

## Validation

- `bun run --cwd packages/core docs:check`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core effect:check`
- `bun run --cwd packages/core test src/router/__tests__/navigation-core.test.ts src/router/__tests__/route-activation.test.ts src/router/__tests__/outlet-navigation.test.tsx src/router/__tests__/outlet-rendering.test.ts src/router/__tests__/service.test.tsx src/primitives/__tests__/render-context-transaction.test.ts src/primitives/__tests__/render-transaction.test.ts src/primitives/__tests__/render-intrinsic.test.tsx`
- `bun run --cwd packages/core test`
- `bun run --cwd apps/www test`
- `bun run build`

Closes #243.
Refs #221.
Refs #222.
Refs #223.
Refs #192.
Part of #212.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #206
2. #207
3. #209
4. #210
5. #211
6. #224
7. #225
8. #244
9. #245
10. #246
11. #247
12. #248
13. #249
14. #250
15. #251
16. #252
17. #253
18. #254
19. #255
20. #256
21. #257
22. #258
23. #259
24. #260
25. #261
26. **#262** 👈 current
<!-- stack:links:end -->